### PR TITLE
match behavior on py2,py3 for classmethod functions

### DIFF
--- a/loman/compat.py
+++ b/loman/compat.py
@@ -33,15 +33,26 @@ if six.PY3:
         raise Exception("Only Python3 >=3.4 is supported")
 elif six.PY2:
     def get_signature(func):
+        print("hello world 22")
         argspec = inspect.getargspec(func)
         has_var_args = argspec.varargs is not None
         has_var_kwds = argspec.keywords is not None
         all_keyword_params = argspec.args
+        #Filter out the 'self' argument in case
+        #the user passes in a class method
+        #It is neccessary to test for 'self'
+        #as well as inspect.ismethod since 
+        #ismethod == True for static methods, 
+        #which should not have the first argument dropped
+        if inspect.ismethod(func) and len(all_keyword_params) and all_keyword_params[0].lower() == 'self':
+            all_keyword_params = all_keyword_params[1:]
         if argspec.defaults is None:
             default_params = []
         else:
             n_default_params = len(argspec.defaults)
             default_params = argspec.args[-n_default_params:]
-        return _Signature(all_keyword_params, default_params, has_var_args, has_var_kwds)
+        output= _Signature(all_keyword_params, default_params, has_var_args, has_var_kwds)
+        print(output)
+        return output
 else:
     raise Exception("Only Pythons 2 and 3 supported")

--- a/loman/compat.py
+++ b/loman/compat.py
@@ -33,7 +33,6 @@ if six.PY3:
         raise Exception("Only Python3 >=3.4 is supported")
 elif six.PY2:
     def get_signature(func):
-        print("hello world 22")
         argspec = inspect.getargspec(func)
         has_var_args = argspec.varargs is not None
         has_var_kwds = argspec.keywords is not None

--- a/loman/compat.py
+++ b/loman/compat.py
@@ -50,8 +50,6 @@ elif six.PY2:
         else:
             n_default_params = len(argspec.defaults)
             default_params = argspec.args[-n_default_params:]
-        output= _Signature(all_keyword_params, default_params, has_var_args, has_var_kwds)
-        print(output)
-        return output
+        return _Signature(all_keyword_params, default_params, has_var_args, has_var_kwds)
 else:
     raise Exception("Only Pythons 2 and 3 supported")

--- a/loman/test/test_computeengine.py
+++ b/loman/test/test_computeengine.py
@@ -1138,3 +1138,14 @@ def test_repoint_missing_node():
     comp.repoint('a', 'new_a')
     assert comp.s.new_a == States.PLACEHOLDER
 
+def test_class_method():
+    class Clazz(object):
+        def method(self,a):
+            return a+2
+    c = loman.Computation()
+    c.add_node("a",value=1)
+    obj = Clazz()    
+    c.add_node("b",obj.method)
+    c.compute_all()
+    assert c.v.b == 3
+


### PR DESCRIPTION
The below test code works in loman under py3, but not py2. 
```
class Clazz(object):
    def method(self,a):
        return a+2
c = loman.Computation()
c.add_node("a",value=1)
obj = Clazz()    
c.add_node("b",obj.method)
c.compute_all()
c.v.b
```
In py3, this prints out 3 and the loman contains 2 nodes:
![image](https://user-images.githubusercontent.com/56136978/67868208-3b45c000-faf1-11e9-90a8-4501543d8071.png)


 In py2 it prints out None, because there is a stale reference to `self`.
![image](https://user-images.githubusercontent.com/56136978/67868131-1a7d6a80-faf1-11e9-8ecd-ad75c8ad639a.png)

This PR updates the get_signature function to check for this scenario and not include self as a possible parameter. 
