### PR TITLE
added test for calc_node w/ no args and fixed this condition in CalcNode

### DIFF
--- a/loman/computeengine.py
+++ b/loman/computeengine.py
@@ -114,7 +114,8 @@ class CalcNode(Node):
         f = self.f
         if ignore_self:
             signature = get_signature(self.f)
-            if signature.kwd_params[0] == 'self':
+            if (len(signature.kwd_params) > 0 and 
+                signature.kwd_params[0] == 'self'):
                 f = f.__get__(obj, obj.__class__)
         if 'ignore_self' in kwds:
             del kwds['ignore_self']

--- a/test/test_class_style_definition.py
+++ b/test/test_class_style_definition.py
@@ -236,3 +236,15 @@ def test_computation_factory_methods_calling_methods_on_self_recursively():
     comp = FooComp()
     comp.compute_all()
     assert comp.s.d == States.UPTODATE and comp.v.d == 10
+
+def test_computation_factory_calc_node_no_args():
+    @ComputationFactory
+    class FooComp():
+
+        @calc_node
+        def a():
+            return 3
+
+    comp = FooComp()
+    comp.compute_all()
+    assert comp.s.a == States.UPTODATE and comp.v.a == 3


### PR DESCRIPTION
The `if` condition in `CalcNode.add_to_comp` expected the callable signature to be of length greater than zero and resulted in an `IndexError` if this was not the case.

This PR includes a bug fix and unit test for this condition.