### PR TITLE
Fix style preservation in linked nodes

### DIFF
--- a/loman/computeengine.py
+++ b/loman/computeengine.py
@@ -1090,7 +1090,7 @@ class Computation:
     def _style_one(self, name: Name):
         node_key = to_nodekey(name)
         node = self.dag.nodes[node_key]
-        return node[NodeAttributes.STYLE]
+        return node.get(NodeAttributes.STYLE)
 
     def styles(self, name: Union[Name, Names]):
         """

--- a/loman/computeengine.py
+++ b/loman/computeengine.py
@@ -1456,6 +1456,7 @@ class Computation:
 
     def add_block(self, base_path: Name, block: 'Computation', *, keep_values: Optional[bool] = True, links: Optional[dict] = None):
         base_path = to_nodekey(base_path)
+        # here can we add the nodes whilst we also add the nodes
         for node_name in block.nodes():
             node_key = to_nodekey(node_name)
             node_data = block.dag.nodes[node_key]
@@ -1482,7 +1483,9 @@ class Computation:
         source = to_nodekey(source)
         if target == source:
             return
-        self.add_node(target, identity_function, kwds={'x': source})
+        target_style = self.styles(target)
+        source_style = self.styles(source)
+        self.add_node(target, identity_function, kwds={'x': source}, style=target_style if target_style else source_style)
 
     def _repr_svg_(self):
         return GraphView(self).svg()

--- a/loman/computeengine.py
+++ b/loman/computeengine.py
@@ -1456,7 +1456,6 @@ class Computation:
 
     def add_block(self, base_path: Name, block: 'Computation', *, keep_values: Optional[bool] = True, links: Optional[dict] = None):
         base_path = to_nodekey(base_path)
-        # here can we add the nodes whilst we also add the nodes
         for node_name in block.nodes():
             node_key = to_nodekey(node_name)
             node_data = block.dag.nodes[node_key]

--- a/loman/computeengine.py
+++ b/loman/computeengine.py
@@ -1482,9 +1482,12 @@ class Computation:
         source = to_nodekey(source)
         if target == source:
             return
-        target_style = self.styles(target)
-        source_style = self.styles(source)
-        self.add_node(target, identity_function, kwds={'x': source}, style=target_style if target_style else source_style)
+
+        target_style = self._style_one(target) if self.has_node(target) else None
+        source_style = self._style_one(source) if self.has_node(source) else None
+        style = target_style if target_style else source_style
+
+        self.add_node(target, identity_function, kwds={'x': source}, style=style)
 
     def _repr_svg_(self):
         return GraphView(self).svg()

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -324,11 +324,12 @@ def test_draw_expanded_block_with_wildcard_2():
                                                     'foo1/bar1/baz1', 'foo1/bar1/baz2', 'foo1/bar2/baz1', 'foo1/bar2/baz2',
                                                     'foo2/bar1/baz1', 'foo2/bar1/baz2', 'foo2/bar2/baz1', 'foo2/bar2/baz2']}
 
-def test_style_preservation():
+def test_style_preservation_with_block_links():
     def build_comp():
         comp = Computation()
         comp.add_node("a", style="dot")
         comp.add_node("b", style="dot")
+        comp.add_node('e', style='dot')
 
         @node(comp, "c")
         def comp_c(a, b):
@@ -340,9 +341,11 @@ def test_style_preservation():
     full_comp = Computation()
     full_comp.add_node("params/a", value=1, style="dot")
     full_comp.add_node("params/b", value=1, style="dot")
+    full_comp.add_node("params/c", value=1, style="dot")
     full_comp.add_block("comp", build_comp(), links={
         "a": "params/a",
-        "b": "params/b"
+        "b": "params/b",
+        "e": "params/c"
     })
 
     expected_styles = ['dot'] * 4 + [None, 'small']

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -4,7 +4,7 @@ from itertools import tee
 import networkx as nx
 
 import loman.visualization
-from loman import Computation, States
+from loman import Computation, States, node
 import loman.computeengine
 from collections import namedtuple
 from loman.consts import NodeTransformations
@@ -323,3 +323,29 @@ def test_draw_expanded_block_with_wildcard_2():
     assert nodes.keys() == {to_nodekey(n) for n in ['input_a',
                                                     'foo1/bar1/baz1', 'foo1/bar1/baz2', 'foo1/bar2/baz1', 'foo1/bar2/baz2',
                                                     'foo2/bar1/baz1', 'foo2/bar1/baz2', 'foo2/bar2/baz1', 'foo2/bar2/baz2']}
+
+def test_style_preservation():
+    def build_comp():
+        comp = Computation()
+        comp.add_node("a", style="dot")
+        comp.add_node("b", style="dot")
+
+        @node(comp, "c")
+        def comp_c(a, b):
+            return a + b
+
+        comp.add_node("d", lambda a: a + 1, style="small")
+        return comp
+
+    full_comp = Computation()
+    full_comp.add_node("params/a", value=1, style="dot")
+    full_comp.add_node("params/b", value=1, style="dot")
+    full_comp.add_block("comp", build_comp(), links={
+        "a": "params/a",
+        "b": "params/b"
+    })
+
+    expected_styles = ['dot'] * 4 + [None, 'small']
+    actual_styles = full_comp.styles(["params/a", 'params/b', 'comp/a', 'comp/b', 'comp/c', 'comp/d'])
+
+    assert expected_styles == actual_styles


### PR DESCRIPTION
#36 fixes style preservation in linked nodes using blocks. 

By default I assume you want to maintain the style of the target node, however if not set assumes style of the source node.  