### PR TITLE
use os.system "open" to achieve os.startfile in linux/unix

### DIFF
--- a/loman/visualization.py
+++ b/loman/visualization.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -346,6 +347,8 @@ class GraphView:
     def view(self):
         with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:
             f.write(self.viz_dot.create_pdf())
+            if sys.platform != "win32":
+                os.system('open %s' % f.name)
             os.startfile(f.name)
 
     def _repr_svg_(self):


### PR DESCRIPTION
os.startfile does not work in windows. Use os.system(...) to open file to achieve same behaviour as on windows