### PR TITLE
Exclude .pre-commit-config.yaml in template.yml

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -7,7 +7,8 @@ include:
 - book/
 - tests/
 - .editorconfig
-- .pre-commit-config.yaml
+# let's not include the pre-commit-config.yaml in an update
+# - .pre-commit-config.yaml
 - Makefile
 - presentation/
 exclude:
@@ -19,3 +20,5 @@ exclude:
 - book/pdoc-templates/
 - book/README.md
 - book/marimo/README.md
+# if we exclude the file Rhiza will not(!) remove the local file
+- .pre-commit-config.yaml


### PR DESCRIPTION
Exclude .pre-commit-config.yaml from updates.

It might be easier if we introudce 

include:

exclude:

Don't touch (what you can't afford):
    - .rhiza/.env
    - .pre-commit-config.yaml
  