### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/tests/test_rhiza/test_makefile.py
+++ b/tests/test_rhiza/test_makefile.py
@@ -153,7 +153,11 @@ class TestMakefile:
 
     def test_fmt_target_dry_run(self, logger, tmp_path):
         """Fmt target should invoke pre-commit via uvx with Python version in dry-run output."""
-        proc = run_make(logger, ["fmt"])
+        # Create clean environment without PYTHON_VERSION so Makefile reads from .python-version
+        env = os.environ.copy()
+        env.pop("PYTHON_VERSION", None)
+
+        proc = run_make(logger, ["fmt"], env=env)
         out = proc.stdout
         # Check for uvx command with the Python version flag
         # The PYTHON_VERSION should be read from .python-version file (e.g., "3.12")
@@ -178,7 +182,12 @@ class TestMakefile:
         env_content += "\nSOURCE_FOLDER=src\n"
         env_file.write_text(env_content)
 
-        proc = run_make(logger, ["deptry"])
+        # Create clean environment without PYTHON_VERSION so Makefile reads from .python-version
+        env = os.environ.copy()
+        env.pop("PYTHON_VERSION", None)
+
+        proc = run_make(logger, ["deptry"], env=env)
+
         out = proc.stdout
         # Check for uvx command with the Python version flag
         python_version_file = tmp_path / ".python-version"


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Tests

<details>
<summary>Modified (1)</summary>

- 📝 `tests/test_rhiza/test_makefile.py`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-01-30T22:05:16Z
- Sync date: 2026-02-02T00:59:29.676607+00:00