### PR TITLE
Zensical docs config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ _book
 _pdoc
 docs/notebooks/*.html
 docs/reports
-docs/reports.md
 _marimushka
 _mkdocs
 _benchmarks

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LOGO_FILE=.rhiza/assets/rhiza-logo.svg
 GH_AW_ENGINE ?= copilot  # Default AI engine for gh-aw workflows (copilot, claude, or codex)
 
 # Override template default: fix quoting bug and typo (mkdocstring -> mkdocstrings)
-MKDOCS_EXTRA_PACKAGES = --with-editable . --with 'mkdocstrings[python]'
+MKDOCS_EXTRA_PACKAGES = --with-editable . --with 'mkdocstrings[python]' --with mkdocs_graphviz
 
 # Always include the Rhiza API (template-managed)
 include .rhiza/rhiza.mk

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -1,12 +1,59 @@
 # Release Checklist
 
-- Check CHANGELOG is up-to-date
-- Check [Travis CI](https://travis-ci.org/janusassetallocation/loman) builds are passing
-- Check [Read The Docs documentation builds](https://readthedocs.org/projects/loman/) are passing
-- Update version string in
-  - pyproject.toml
-  - docs/conf.py
-- Commit updated versions and tag
-- Build the tar.gz and wheel: `python -m build`
-- Upload the tar.gz and wheel: `twine upload dist\loman-x.y.z*`
-- Email the community
+Releases are largely automated through the rhiza release workflow. The local
+`make` targets handle version bumping and tagging; the `(RHIZA) RELEASE`
+workflow on GitHub Actions takes over once the tag is pushed and handles
+building, SBOM generation, PyPI publishing (via OIDC Trusted Publishing), and
+creating the GitHub release.
+
+## Pre-release checks
+
+- Confirm `main` is green on the `(RHIZA) CI` workflow.
+- Update [`CHANGELOG.md`](../../CHANGELOG.md).
+
+## Cut the release
+
+Use `make publish` to bump the version, tag, and push in one step:
+
+```bash
+make publish
+```
+
+This invokes `rhiza-tools release --with-bump`, which:
+
+1. Bumps the version in `pyproject.toml` and refreshes `uv.lock`.
+2. Commits the bump.
+3. Creates a `vX.Y.Z` tag and pushes it to the remote.
+
+If you prefer the two phases separately:
+
+```bash
+make bump      # bump version + update uv.lock + commit
+make release   # tag and push
+```
+
+Add `DRY_RUN=1` to either target to preview without applying.
+
+## Automated workflow (triggered by tag push)
+
+Once the `v*` tag is pushed, the `(RHIZA) RELEASE` workflow runs and:
+
+- Validates the tag.
+- Builds the sdist + wheel.
+- Generates a CycloneDX SBOM with attestations.
+- Drafts a GitHub release with artifacts.
+- Publishes to PyPI via OIDC Trusted Publishing.
+- Finalises (publishes) the GitHub release.
+
+In parallel, `(RHIZA) BOOK` rebuilds and deploys the documentation site to
+GitHub Pages.
+
+## Post-release
+
+Check status with:
+
+```bash
+make release-status
+```
+
+This shows the latest workflow run and the published release.

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -1,0 +1,9 @@
+# Notebooks
+
+Interactive [Marimo](https://marimo.io/) notebooks demonstrating Loman in
+practice. Each notebook is exported as a self-contained HTML page.
+
+- [CDOs](notebooks/cdos.html)
+- [Interest Rate Swaps](notebooks/interest_rate_swaps.html)
+- [Portfolio](notebooks/portfolio.html)
+- [Serialization](notebooks/serialization.html)

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,0 +1,6 @@
+# Reports
+
+Generated test and coverage reports for the latest build.
+
+- [Test Report](reports/html-report/report.html) — pytest results.
+- [Coverage Report](reports/html-coverage/index.html) — line/branch coverage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ repo_url: https://github.com/janushendersonassetallocation/loman
 repo_name: janushendersonassetallocation/loman
 
 docs_dir: docs
-site_dir: _mkdocs
+site_dir: _book
 
 theme:
   name: material
@@ -21,7 +21,7 @@ extra:
   version:
     provider: mike
 
-use_directory_urls: false
+use_directory_urls: true
 
 plugins:
   - search
@@ -58,10 +58,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Getting Started: user/quickstart.md
-  - Marimo Notebooks: notebooks.md
-  - Reports: reports.md
-  - API Reference: api.md
+  - Quickstart: user/quickstart.md
   - User Guide:
       - Introduction: user/intro.md
       - Installation: user/install.md
@@ -84,16 +81,21 @@ nav:
               - Interactive Debugging: user/features/other/interactive_debugging.md
               - Serializing Computations: user/features/other/serializing_computations.md
               - Migrating from write_dill: user/features/other/migrating_from_dill.md
+  - Notebooks:
+      - Overview: notebooks.md
+      - CDOs: notebooks/cdos.html
+      - Interest Rate Swaps: notebooks/interest_rate_swaps.html
+      - Portfolio: notebooks/portfolio.html
+      - Serialization: notebooks/serialization.html
+  - Reports:
+      - Overview: reports.md
+      - Test Report: reports/html-report/report.html
+      - Coverage Report: reports/html-coverage/index.html
+  - API Reference: api.md
   - Developer:
       - Release Checklist: dev/release.md
-      - Architecture: ARCHITECTURE.md
-      - Testing: TESTS.md
-      - Security: SECURITY.md
-  - Reference:
-      - Quick Reference: QUICK_REFERENCE.md
-      - Glossary: GLOSSARY.md
-      - Customization: CUSTOMIZATION.md
-      - DevContainer: DEVCONTAINER.md
-      - Demo: DEMO.md
+      - DevContainer: development/DEVCONTAINER.md
+      - Marimo: development/MARIMO.md
+      - Testing: development/TESTS.md
       - Contributing: CONTRIBUTING.md
       - Code of Conduct: CODE_OF_CONDUCT.md


### PR DESCRIPTION
This pull request updates the documentation and build configuration to improve the release workflow, enhance the documentation site structure, and add new content. The most significant changes include a rewritten release process, reorganization and expansion of documentation navigation, and the addition of new notebook and report pages.

**Release Workflow Improvements**
- Rewrote `docs/dev/release.md` to describe the new automated release workflow using `make` targets and GitHub Actions, replacing the old manual checklist. The new process covers version bumping, tagging, automated builds, PyPI publishing, and post-release checks.

**Documentation Structure and Navigation**
- Updated `mkdocs.yml` navigation to reorganize and expand the sidebar: moved and renamed sections for clarity, grouped notebooks and reports under their own headings, and updated developer references to point to new locations. [[1]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L61-R61) [[2]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R84-R99)
- Changed the documentation output directory from `_mkdocs` to `_book` for consistency with deployment workflows.
- Enabled directory-style URLs in the documentation site for cleaner, more user-friendly links.

**New Documentation Content**
- Added a new Notebooks overview page (`docs/notebooks.md`) describing interactive Marimo notebooks, with links to individual notebook HTML exports.
- Added a new Reports overview page (`docs/reports.md`) with links to the latest test and coverage reports.

**Build and Plugin Enhancements**
- Updated the `Makefile` to include the `mkdocs_graphviz` plugin for enhanced diagram support in documentation builds.