### PR TITLE
test: coverage tests, graphviz skip marker, and dependency lower bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
 ]
 test = [
     "pytest>=7.0",
+    "pytest-xdist>=3.0",
 ]
 lint = [
     "ruff>=0.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -21,13 +24,13 @@ classifiers = [
 license = "BSD-3-Clause"
 license-files = ["LICEN[CS]E*"]
 dependencies = [
-    "decorator",
-    "matplotlib",
-    "numpy",
-    "pydotplus",
-    "dill >= 0.2.5",
-    "networkx >= 2.0",
-    "pandas >= 0.19.2",
+    "decorator>=4.0",
+    "matplotlib>=3.8",
+    "numpy>=1.26",
+    "pydotplus>=2.0",
+    "dill >= 0.3.8",
+    "networkx >= 2.6",
+    "pandas >= 2.2",
     "attrs >= 25.0"
 ]
 
@@ -38,9 +41,17 @@ dev = [
     "marimo>=0.15",
     "scipy>=1.16.3",
 ]
+test = [
+    "pytest>=7.0",
+]
+lint = [
+    "ruff>=0.12.0",
+    "mypy>=1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/janusassetallocation/loman"
+Repository = "https://github.com/janusassetallocation/loman"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/loman"]
@@ -61,3 +72,6 @@ dill = "dill"
 
 [tool.bandit]
 skips = ["B301", "B403", "B404"]
+
+[tool.interrogate]
+ignore-overloaded-functions = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,22 @@ Security Notes:
 - S603/S607 (subprocess usage): Any subprocess calls use controlled inputs in test environments
 """
 
+import shutil
+
+import pytest
+
 from loman import Computation, ComputationFactory, calc_node, input_node
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line("markers", "requires_graphviz: tests that require the graphviz 'dot' executable")
+
+
+def pytest_runtest_setup(item):
+    """Skip tests marked requires_graphviz when the dot executable is absent."""
+    if item.get_closest_marker("requires_graphviz") and shutil.which("dot") is None:
+        pytest.skip("graphviz (dot) not installed")
 
 
 @ComputationFactory

--- a/tests/test_computeengine.py
+++ b/tests/test_computeengine.py
@@ -3519,6 +3519,7 @@ class TestAttributeViewPathCoverage:
         assert "child2" in node_names or any("child2" in str(n) for n in node_names)
 
 
+@pytest.mark.requires_graphviz
 class TestComputationReprSvgCoverage:
     """Test Computation _repr_svg_."""
 
@@ -3817,3 +3818,26 @@ class TestComputeengineRemainingCoverageCoverage:
         # Check that names are relative (without "parent/" prefix)
         for name in names:
             assert not str(name).startswith("parent/")
+
+
+class TestPrivateMethodsCoverage:
+    """Coverage for internal methods not exercised through the public API."""
+
+    def test_get_descendents_no_stop_states(self):
+        """_get_descendents without stop_states exercises the default branch (line 935)."""
+        comp = Computation()
+        comp.add_node("a", value=1)
+        comp.add_node("b", lambda a: a + 1)
+        nk_a = to_nodekey("a")
+        nk_b = to_nodekey("b")
+        result = comp._get_descendents(nk_a)
+        assert nk_b in result
+
+    def test_to_dict_method(self):
+        """Computation.to_dict returns {NodeKey: value} for UPTODATE nodes (lines 1471-1472)."""
+        comp = Computation()
+        comp.add_node("x", value=42)
+        comp.add_node("y", value="hello")
+        result = comp.to_dict()
+        assert result[to_nodekey("x")] == 42
+        assert result[to_nodekey("y")] == "hello"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1439,3 +1439,182 @@ class TestJsonRoundtrip:
         assert comp2.value(nk_a) == 3
         assert comp2.state(nk_d) == States.UPTODATE
         assert comp2.value(nk_d) == inner.value("d")
+
+
+# =============================================================================
+# Additional coverage tests for previously uncovered lines
+# =============================================================================
+
+
+class TestComputationSerializerDumpsLoads:
+    """Cover ComputationSerializer.dumps (line 144) and .loads (lines 256-257)."""
+
+    def test_dumps_returns_json_string(self):
+        """Dumps serializes to a JSON string."""
+        s = ComputationSerializer()
+        comp = Computation()
+        comp.add_node("a", value=1)
+        result = s.dumps(comp)
+        assert isinstance(result, str)
+        data = json.loads(result)
+        assert "nodes" in data
+
+    def test_loads_round_trips(self):
+        """Loads deserializes a JSON string produced by dumps."""
+        s = ComputationSerializer()
+        comp = Computation()
+        comp.add_node("a", value=42)
+        json_str = s.dumps(comp)
+        comp2 = s.loads(json_str)
+        assert comp2.state("a") == States.UPTODATE
+        assert comp2.value("a") == 42
+
+
+class TestSerializeNonValueState:
+    """Cover _serialize_node_value when state is not in VALUE_STATES (line 155)."""
+
+    def test_uninitialized_node_serializes_without_value(self):
+        """An UNINITIALIZED node (no value) is written with has_value=False (covers line 155)."""
+        comp = Computation()
+        comp.add_node("a")  # UNINITIALIZED — state not in {UPTODATE, PINNED, ERROR}
+
+        buf = io.StringIO()
+        comp.write_json(buf)
+        data = json.loads(buf.getvalue())
+        a_node = next(n for n in data["nodes"] if n["key"] == "a")
+        assert a_node["has_value"] is False
+
+
+class TestSerializeUnserializableValue:
+    """Cover the SerializationError path in _serialize_node_value (lines 171-173)."""
+
+    def test_unserializable_uptodate_value_raises(self):
+        """A node whose value cannot be encoded raises SerializationError."""
+
+        class _Opaque:
+            pass
+
+        comp = Computation()
+        comp.add_node("a", value=_Opaque())
+
+        s = ComputationSerializer()
+        buf = io.StringIO()
+        with pytest.raises(SerializationError, match="Cannot serialize value"):
+            comp.write_json(buf, serializer=s)
+
+
+class TestSerializeEdgeWithoutParam:
+    """Cover _serialize_edge with no PARAM (line 231) and _from_dict edge without param_type (line 317)."""
+
+    def test_edge_without_param_round_trips(self):
+        """An edge added directly to the DAG without PARAM data serializes with param_type=null."""
+        from loman.nodekey import to_nodekey as tnk
+
+        comp = Computation()
+        comp.add_node("a", value=1)
+        comp.add_node("b", value=2)
+        nk_a = tnk("a")
+        nk_b = tnk("b")
+        comp.dag.add_edge(nk_a, nk_b)  # no EdgeAttributes.PARAM
+
+        buf = io.StringIO()
+        comp.write_json(buf)  # covers line 231
+        raw = json.loads(buf.getvalue())
+        edge = next(e for e in raw["edges"] if e["src"] == "a" and e["dst"] == "b")
+        assert edge["param_type"] is None
+
+        buf.seek(0)
+        comp2 = Computation.read_json(buf)  # covers line 317
+        assert comp2.has_node("a")
+        assert comp2.has_node("b")
+
+
+class TestSerializeUserTags:
+    """Cover the user-tag loop in _from_dict (line 305)."""
+
+    def test_user_tag_preserved_after_roundtrip(self):
+        """User tags (not starting with __) survive a JSON roundtrip."""
+        from loman.consts import NodeAttributes
+
+        comp = Computation()
+        comp.add_node("a", value=1)
+        comp.set_tag("a", "my_custom_tag")
+
+        s = ComputationSerializer()
+        json_str = s.dumps(comp)
+        comp2 = s.loads(json_str)
+
+        nk = parse_nodekey("a")
+        tags = comp2.dag.nodes[nk][NodeAttributes.TAG]
+        assert "my_custom_tag" in tags
+
+
+class TestEnumTransformerUnknownClass:
+    """Cover EnumTransformer.from_dict with unregistered enum class (lines 395-396)."""
+
+    def test_unknown_enum_class_raises(self):
+        """from_dict raises UnrecognizedTypeException for an unregistered enum class."""
+        from loman.serialization.transformer import EnumTransformer
+
+        et = EnumTransformer()
+        t = Transformer()
+        d = {"enum_class": "NoSuchEnum", "value": "MEMBER"}
+        with pytest.raises(UnrecognizedTypeException, match="Unknown enum class"):
+            et.from_dict(t, d)
+
+
+class TestFunctionRefTransformerEdgeCases:
+    """Cover FunctionRefTransformer error paths (lines 420-421, 425-426, 440-441)."""
+
+    def test_not_callable_raises_type_error(self):
+        """to_dict with a non-callable raises TypeError (lines 420-421)."""
+        from loman.serialization.transformer import FunctionRefTransformer
+
+        frt = FunctionRefTransformer()
+        t = Transformer()
+        with pytest.raises(TypeError, match="not callable"):
+            frt.to_dict(t, "not_a_function")
+
+    def test_missing_qualname_raises_value_error(self):
+        """to_dict with a callable lacking __qualname__ raises ValueError (lines 425-426)."""
+        import functools
+
+        from loman.serialization.transformer import FunctionRefTransformer
+
+        frt = FunctionRefTransformer()
+        t = Transformer()
+        p = functools.partial(len)  # partial objects have no __qualname__
+        with pytest.raises(ValueError, match="missing __qualname__"):
+            frt.to_dict(t, p)
+
+    def test_import_roundtrip_mismatch_raises(self):
+        """to_dict raises ValueError when import round-trip returns a different object (lines 440-441)."""
+        from loman.serialization.transformer import FunctionRefTransformer
+
+        frt = FunctionRefTransformer()
+        t = Transformer()
+
+        class MyCallable:
+            def __call__(self):
+                pass
+
+        # Set instance attributes so the callable *looks* importable as json.dumps,
+        # but is obviously a different object (import json; json.dumps is not obj).
+        obj = MyCallable()
+        obj.__qualname__ = "dumps"  # type: ignore[attr-defined]
+        obj.__module__ = "json"  # type: ignore[attr-defined]
+        with pytest.raises(ValueError, match="import round-trip returned a different object"):
+            frt.to_dict(t, obj)
+
+
+class TestDillFunctionTransformerNotCallable:
+    """Cover DillFunctionTransformer.to_dict with non-callable (lines 509-510)."""
+
+    def test_not_callable_raises_type_error(self):
+        """to_dict with a non-callable raises TypeError."""
+        from loman.serialization import DillFunctionTransformer
+
+        dft = DillFunctionTransformer()
+        t = Transformer()
+        with pytest.raises(TypeError, match="not callable"):
+            dft.to_dict(t, 42)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -720,6 +720,7 @@ class TestVisualizationCoverage:
         v.viz_dot = None
         assert v.svg() is None
 
+    @pytest.mark.requires_graphviz
     def test_graph_view_repr_svg(self):
         """Test GraphView._repr_svg_() method."""
         comp = Computation()
@@ -729,6 +730,7 @@ class TestVisualizationCoverage:
         assert svg is not None
         assert "<svg" in svg
 
+    @pytest.mark.requires_graphviz
     @patch("subprocess.run")
     @patch("tempfile.NamedTemporaryFile")
     def test_graph_view_view_linux(self, mock_tempfile, mock_run):
@@ -819,6 +821,7 @@ class TestVisualizationAttrNormalization:
         assert root is not None
 
 
+@pytest.mark.requires_graphviz
 class TestGraphViewCollapse:
     """Tests for GraphView with collapse_all."""
 
@@ -844,6 +847,7 @@ class TestGraphViewCollapse:
         assert svg is not None
 
 
+@pytest.mark.requires_graphviz
 class TestGraphViewEmpty:
     """Test GraphView with empty computation."""
 
@@ -858,6 +862,7 @@ class TestGraphViewEmpty:
         assert "<svg" in svg
 
 
+@pytest.mark.requires_graphviz
 class TestVisualizationWin32Branch:
     """Test the Windows platform branch in view()."""
 
@@ -891,6 +896,7 @@ class TestVisualizationCalibrate:
         f.calibrate([])  # Should do nothing, no error
 
 
+@pytest.mark.requires_graphviz
 class TestCollapseNodeMapped:
     """Test the collapse logic in visualization."""
 
@@ -965,6 +971,7 @@ class TestVisualizationOpenPdf:
         assert "open" in mock_run.call_args[0][0]
 
 
+@pytest.mark.requires_graphviz
 class TestVisualizationWithNoneCmap:
     """Test visualization with None colormap."""
 
@@ -1051,6 +1058,7 @@ class TestRenameMetadataClearBranch:
         assert comp.metadata("new_name") == {}
 
 
+@pytest.mark.requires_graphviz
 class TestGraphViewWithRootNode:
     """Test GraphView with root parameter filtering."""
 
@@ -1067,6 +1075,7 @@ class TestGraphViewWithRootNode:
         assert svg is not None
 
 
+@pytest.mark.requires_graphviz
 class TestGraphViewNoneFormatter:
     """Tests for GraphView with node_formatter=None."""
 
@@ -1080,6 +1089,7 @@ class TestGraphViewNoneFormatter:
         assert svg is not None
 
 
+@pytest.mark.requires_graphviz
 class TestColormapNodeFormatter:
     """Tests for colormap in node formatter."""
 
@@ -1167,6 +1177,7 @@ class TestRectBlocksCoverage:
         assert result is None
 
 
+@pytest.mark.requires_graphviz
 class TestGraphViewTransformations:
     """Test GraphView with transformations."""
 
@@ -1204,6 +1215,7 @@ class TestStandardStylingOverridesCoverage:
         assert result is None
 
 
+@pytest.mark.requires_graphviz
 class TestVisualizationDropRootNone:
     """Test visualization when drop_root returns None."""
 
@@ -1245,6 +1257,7 @@ class TestVisualizationSubprocess:
         assert "open" in call_args
 
 
+@pytest.mark.requires_graphviz
 class TestVisualizationVizDagFormatterNone:
     """Test create_viz_dag with node_formatter=None."""
 
@@ -1258,3 +1271,39 @@ class TestVisualizationVizDagFormatterNone:
         # Should still produce valid SVG
         svg = v.svg()
         assert svg is not None
+
+
+class TestColorByTimingCompositeNode:
+    """Cover ColorByTiming.format when len(nodes) != 1 (line 160)."""
+
+    def test_format_composite_node_returns_none(self):
+        """Format with multiple nodes returns None (covers line 160)."""
+        from datetime import datetime
+
+        cbt = ColorByTiming()
+        nk = NodeKey(("group",))
+        now = datetime.now()
+        node1 = Node(NodeKey(("group", "a")), nk, {NodeAttributes.TIMING: TimingData(now, now, 0.1)})
+        node2 = Node(NodeKey(("group", "b")), nk, {NodeAttributes.TIMING: TimingData(now, now, 0.5)})
+        result = cbt.format(nk, [node1, node2], is_composite=True)
+        assert result is None
+
+
+class TestShapeByTypeCalibrateAndComposite:
+    """Cover ShapeByType.calibrate (line 168) and composite format (line 191)."""
+
+    def test_calibrate_runs_without_error(self):
+        """Calibrate on ShapeByType is a no-op but must be executed (line 168)."""
+        sbt = ShapeByType()
+        nk = NodeKey(("a",))
+        n = Node(nk, nk, {NodeAttributes.VALUE: 1})
+        sbt.calibrate([n])  # covers the `pass` on line 168
+
+    def test_format_composite_returns_none(self):
+        """Format with multiple nodes returns None (covers line 191)."""
+        sbt = ShapeByType()
+        nk = NodeKey(("group",))
+        node1 = Node(NodeKey(("group", "a")), nk, {NodeAttributes.VALUE: 1})
+        node2 = Node(NodeKey(("group", "b")), nk, {NodeAttributes.VALUE: 2})
+        result = sbt.format(nk, [node1, node2], is_composite=True)
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -245,6 +245,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.62.1"
 source = { registry = "https://pypi.org/simple" }
@@ -548,6 +557,7 @@ lint = [
 ]
 test = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -573,7 +583,10 @@ lint = [
     { name = "mypy", specifier = ">=1.0" },
     { name = "ruff", specifier = ">=0.12.0" },
 ]
-test = [{ name = "pytest", specifier = ">=7.0" }]
+test = [
+    { name = "pytest", specifier = ">=7.0" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
+]
 
 [[package]]
 name = "loro"
@@ -1245,6 +1258,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -312,6 +312,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -533,17 +542,24 @@ dev = [
     { name = "ruff" },
     { name = "scipy" },
 ]
+lint = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+test = [
+    { name = "pytest" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=25.0" },
-    { name = "decorator" },
-    { name = "dill", specifier = ">=0.2.5" },
-    { name = "matplotlib" },
-    { name = "networkx", specifier = ">=2.0" },
-    { name = "numpy" },
-    { name = "pandas", specifier = ">=0.19.2" },
-    { name = "pydotplus" },
+    { name = "decorator", specifier = ">=4.0" },
+    { name = "dill", specifier = ">=0.3.8" },
+    { name = "matplotlib", specifier = ">=3.8" },
+    { name = "networkx", specifier = ">=2.6" },
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "pandas", specifier = ">=2.2" },
+    { name = "pydotplus", specifier = ">=2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -553,6 +569,11 @@ dev = [
     { name = "ruff", specifier = ">=0.12.0" },
     { name = "scipy", specifier = ">=1.16.3" },
 ]
+lint = [
+    { name = "mypy", specifier = ">=1.0" },
+    { name = "ruff", specifier = ">=0.12.0" },
+]
+test = [{ name = "pytest", specifier = ">=7.0" }]
 
 [[package]]
 name = "loro"
@@ -1125,6 +1146,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1199,6 +1229,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Splits out the test-related changes from #293. Adds new coverage tests, introduces a `requires_graphviz` pytest marker so tests skip gracefully when graphviz is not installed, and tightens dependency lower bounds so `uv sync --resolution lowest-direct` resolves versions that build cleanly on Python 3.12.

## Changes

- **tests/conftest.py** — register `requires_graphviz` marker via `pytest_configure`; hook `pytest_runtest_setup` to skip marked tests when `dot` is absent. The lowest-direct CI job runs pytest directly (not via `make test`), so `build-extras.sh` never runs and graphviz is never installed.
- **tests/test_visualization.py** — apply `@pytest.mark.requires_graphviz` to all classes/methods that call `v.svg()` or `_repr_svg_()`.
- **tests/test_computeengine.py** — apply `requires_graphviz` to `TestComputationReprSvgCoverage`; add `TestPrivateMethodsCoverage` (tests for `_get_descendents` and `to_dict`).
- **tests/test_serialization.py** — ~180 lines of new coverage tests for `ComputationSerializer.dumps`/`loads`, edge cases, and roundtrip paths.
- **pyproject.toml** — add lower bounds to previously unpinned dependencies (`decorator>=4.0`, `matplotlib>=3.8`, `numpy>=1.26`, `pydotplus>=2.0`, `dill>=0.3.8`, `networkx>=2.6`, `pandas>=2.2`); add `test`/`lint` dependency groups; add `tool.interrogate` config.

## Testing

- `make test` passes locally
- `uv sync --resolution lowest-direct && uv run pytest tests -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)