### PR TITLE
feat: add make doctor target for prerequisite diagnostics

### DIFF
--- a/.rhiza/make.d/doctor.mk
+++ b/.rhiza/make.d/doctor.mk
@@ -1,0 +1,60 @@
+## .rhiza/make.d/doctor.mk - Developer prerequisite diagnostics
+
+.PHONY: doctor
+
+##@ Dev
+doctor: ## verify local prerequisites and print actionable guidance
+	@failed=0; \
+	version_ge() { \
+		awk -v a="$$1" -v b="$$2" 'BEGIN { \
+			split(a, A, /[^0-9]+/); \
+			split(b, B, /[^0-9]+/); \
+			for (i = 1; i <= 3; i++) { \
+				ai = A[i] + 0; \
+				bi = B[i] + 0; \
+				if (ai > bi) exit 0; \
+				if (ai < bi) exit 1; \
+			} \
+			exit 0; \
+		}'; \
+	}; \
+	check_tool() { \
+		tool="$$1"; min="$$2"; install_url="$$3"; version_cmd="$$4"; gnu_required="$$5"; \
+		if ! command -v "$$tool" >/dev/null 2>&1; then \
+			printf "${RED}[❌]${RESET} %-9s missing — install: %s\n" "$$tool" "$$install_url"; \
+			failed=1; \
+			return; \
+		fi; \
+		version="$$(eval "$$version_cmd" 2>/dev/null)"; \
+		if [ -z "$$version" ]; then \
+			printf "${RED}[❌]${RESET} %-9s unknown version (required ≥ %s)\n" "$$tool" "$$min"; \
+			failed=1; \
+			return; \
+		fi; \
+		extra=""; \
+		if [ "$$gnu_required" = "gnu" ] && ! make --version 2>/dev/null | grep -q '^GNU Make'; then \
+			extra=" (GNU required)"; \
+			printf "${RED}[❌]${RESET} %-9s %-8s < %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+			failed=1; \
+			return; \
+		fi; \
+		if version_ge "$$version" "$$min"; then \
+			if [ "$$gnu_required" = "gnu" ]; then \
+				extra=" (GNU required)"; \
+			fi; \
+			printf "${GREEN}[✅]${RESET} %-9s %-8s ≥ %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+		else \
+			if [ "$$gnu_required" = "gnu" ]; then \
+				extra=" (GNU required)"; \
+			fi; \
+			printf "${RED}[❌]${RESET} %-9s %-8s < %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+			failed=1; \
+		fi; \
+	}; \
+	check_tool "uv" "0.4.0" "https://docs.astral.sh/uv/getting-started/installation/" "uv --version | awk 'NR==1 {print \$$2}'" ""; \
+	check_tool "make" "3.8.0" "https://www.gnu.org/software/make/" "make --version | awk 'NR==1 {for (i=1; i<=NF; i++) if (\$$i ~ /^[0-9]+(\\.[0-9]+)+$$/) {print \$$i; exit}}'" "gnu"; \
+	check_tool "git" "2.0.0" "https://git-scm.com" "git --version | awk 'NR==1 {print \$$3}'" ""; \
+	if [ "$$failed" -ne 0 ]; then \
+		printf "\n${YELLOW}[WARN] One or more prerequisites are missing or below minimum version.${RESET}\n"; \
+		exit 1; \
+	fi

--- a/.rhiza/tests/api/conftest.py
+++ b/.rhiza/tests/api/conftest.py
@@ -35,6 +35,7 @@ SPLIT_MAKEFILES = [
     ".rhiza/make.d/bootstrap.mk",
     ".rhiza/make.d/quality.mk",
     ".rhiza/make.d/releasing.mk",
+    ".rhiza/make.d/doctor.mk",
     ".rhiza/make.d/test.mk",
     ".rhiza/make.d/book.mk",
     ".rhiza/make.d/marimo.mk",

--- a/.rhiza/tests/api/test_makefile_targets.py
+++ b/.rhiza/tests/api/test_makefile_targets.py
@@ -50,6 +50,38 @@ class TestMakefile:
         assert "Targets:" in out
         assert "Bootstrap" in out or "Meta" in out  # section headers
 
+    def test_doctor_target_appears_in_help(self, logger):
+        """Doctor target should appear in help under the Dev section."""
+        proc = run_make(logger, ["help"])
+        out = proc.stdout
+        assert "Dev" in out
+        assert "doctor" in out
+
+    def test_doctor_fails_when_minimum_version_is_not_met(self, logger, tmp_path):
+        """Doctor should exit non-zero when a prerequisite version is below the minimum."""
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir(exist_ok=True)
+
+        for name, content in {
+            "uv": "#!/usr/bin/env sh\necho 'uv 0.3.0'\n",
+            "python": "#!/usr/bin/env sh\necho 'Python 3.12.2'\n",
+            "make": "#!/usr/bin/env sh\necho 'GNU Make 4.4.1'\n",
+            "git": "#!/usr/bin/env sh\necho 'git version 2.44.0'\n",
+        }.items():
+            script = fake_bin / name
+            script.write_text(content)
+            script.chmod(0o755)
+
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+
+        proc = run_make(logger, ["doctor"], dry_run=False, check=False, env=env)
+        out = strip_ansi(proc.stdout)
+        assert proc.returncode != 0
+        assert "[❌] uv" in out
+        assert "0.3.0" in out
+        assert "0.4.0" in out
+
     def test_fmt_target_dry_run(self, logger, tmp_path):
         """Fmt target should invoke pre-commit via uvx with Python version in dry-run output."""
         # Create clean environment without PYTHON_VERSION so Makefile reads from .python-version


### PR DESCRIPTION
## Summary

Adds a `make doctor` target that checks local developer prerequisites against minimum required versions and prints colour-coded pass/fail output with install links.

## Changes

- `.rhiza/make.d/doctor.mk` — new target; checks `uv>=0.4.0`, GNU `make>=3.8`, `git>=2.0` using a pure-awk version comparator, no external dependencies required
- `.rhiza/tests/api/conftest.py` — register `doctor.mk` in `SPLIT_MAKEFILES` so the API test suite validates it alongside other `.mk` files
- `.rhiza/tests/api/test_makefile_targets.py` — two new tests: verify `doctor` appears under the **Dev** section in `make help`, and verify it exits non-zero with actionable `[❌]` output when a tool is below the minimum version

## Testing

- [ ] `make test` passes locally
- [ ] `make doctor` runs and reports tool versions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)