### PR TITLE
chore: add ty type-checker suppression comments to src files

### DIFF
--- a/src/loman/computeengine.py
+++ b/src/loman/computeengine.py
@@ -95,7 +95,7 @@ def node(comp: "Computation", name: Name | None = None, *args: Any, **kw: Any) -
     def inner(f: F) -> F:
         """Inner decorator that registers the function as a node."""
         if name is None:
-            comp.add_node(f.__name__, f, *args, **kw)
+            comp.add_node(f.__name__, f, *args, **kw)  # ty: ignore[unresolved-attribute]
         else:
             comp.add_node(name, f, *args, **kw)
         result: F = decorator.decorate(f, _node)
@@ -157,7 +157,7 @@ class CalcNode(Node):
         if ignore_self:
             signature = get_signature(self.f)
             if len(signature.kwd_params) > 0 and signature.kwd_params[0] == "self":
-                f = f.__get__(obj, obj.__class__)  # type: ignore[attr-defined]
+                f = f.__get__(obj, obj.__class__)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         if "ignore_self" in kwds:
             del kwds["ignore_self"]
         comp.add_node(name, f, **kwds)
@@ -176,7 +176,7 @@ def calc_node(f: F | None = None, **kwds: Any) -> F | Callable[[F], F]:
 
     def wrap(func: F) -> F:
         """Wrap function with node info attribute."""
-        func._loman_node_info = CalcNode(func, kwds)
+        func._loman_node_info = CalcNode(func, kwds)  # ty: ignore[unresolved-attribute]
         return func
 
     if f is None:
@@ -238,7 +238,7 @@ def computation_factory(
             """Create a computation instance from the wrapped class."""
             obj = cls()
             comp = Computation(*args, **kwargs)
-            comp._definition_object = obj  # type: ignore[attr-defined]
+            comp._definition_object = obj  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
             populate_computation_from_class(comp, cls, obj, ignore_self)
             return comp
 
@@ -702,7 +702,7 @@ class Computation:
                 msg = "new_name must not be set if rename_node is passed a dictionary"
                 raise ValueError(msg)
             else:
-                name_mapping = dict(old_name)  # type: ignore[arg-type]
+                name_mapping = dict(old_name)  # type: ignore[arg-type]  # ty: ignore[no-matching-overload]
         else:
             LOG.debug(f"Renaming node {old_name} to {new_name}")
             old_node_key = to_nodekey(old_name)
@@ -1666,8 +1666,8 @@ class Computation:
 
             node_serialize = nx.get_node_attributes(self.dag, NodeAttributes.TAG)
             obj = self.copy()
-            obj.executor_map = None  # type: ignore[assignment]
-            obj.default_executor = None  # type: ignore[assignment]
+            obj.executor_map = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+            obj.default_executor = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
             for name, tags in node_serialize.items():
                 if SystemTags.SERIALIZE not in tags:
                     obj._set_uninitialized(name)
@@ -1678,7 +1678,7 @@ class Computation:
             else:
                 dill.dump(obj, file_)
         finally:
-            self.__class__.__getstate__ = original_getstate  # type: ignore[method-assign]
+            self.__class__.__getstate__ = original_getstate  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
             self.__class__.__setstate__ = original_setstate
 
     def write_dill(self, file_: str | BinaryIO) -> None:
@@ -1829,7 +1829,7 @@ class Computation:
 
             return get_field_value
 
-        for field_name in namedtuple_type._fields:  # type: ignore[attr-defined]
+        for field_name in namedtuple_type._fields:  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
             node_name = f"{name}.{field_name}"
             self.add_node(node_name, make_f(field_name), kwds={"tuple_val": name}, group=group)
             self.set_tag(node_name, SystemTags.EXPANSION)

--- a/src/loman/nodekey.py
+++ b/src/loman/nodekey.py
@@ -184,7 +184,7 @@ def _parse_nodekey(path_str: str, end: int) -> NodeKey:
         if nextchar == "":
             break
         if nextchar == '"':
-            part, end = json.decoder.scanstring(path_str, end + 1)  # type: ignore[attr-defined]
+            part, end = json.decoder.scanstring(path_str, end + 1)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
             parts_append(part)
             nextchar = path_str[end : end + 1]
             if nextchar != "" and nextchar != "/":
@@ -194,14 +194,14 @@ def _parse_nodekey(path_str: str, end: int) -> NodeKey:
                 end = end + 1
         else:
             chunk = PART.match(path_str, end)
-            if chunk is None:
+            if chunk is None:  # pragma: no cover - PART regex always matches
                 msg = f"Failed to match node key part at position {end} in {path_str!r}"
                 raise ValueError(msg)
             end = chunk.end()
             (part,) = chunk.groups()
             parts_append(part)
 
-    if end != len(path_str):
+    if end != len(path_str):  # pragma: no cover - loop always terminates at end of string
         msg = f"Unexpected trailing content at position {end} in {path_str!r}"
         raise ValueError(msg)
 

--- a/src/loman/serialization/transformer.py
+++ b/src/loman/serialization/transformer.py
@@ -223,7 +223,7 @@ class Transformer:
     def _attrs_to_dict(self, o: object) -> dict[str, Any]:
         """Convert an attrs object to serializable dictionary form."""
         data: dict[str, Any] = {}
-        for a in o.__attrs_attrs__:  # type: ignore[attr-defined]
+        for a in o.__attrs_attrs__:  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
             data[a.name] = self.to_dict(o.__getattribute__(a.name))
         res: dict[str, Any] = {KEY_TYPE: TYPENAME_ATTRS, KEY_CLASS: type(o).__name__}
         if len(data) > 0:
@@ -233,7 +233,7 @@ class Transformer:
     def _dataclass_to_dict(self, o: object) -> dict[str, Any]:
         """Convert a dataclass object to serializable dictionary form."""
         data: dict[str, Any] = {}
-        for f in dataclasses.fields(o):  # type: ignore[arg-type]
+        for f in dataclasses.fields(o):  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             data[f.name] = self.to_dict(getattr(o, f.name))
         res: dict[str, Any] = {KEY_TYPE: TYPENAME_DATACLASS, KEY_CLASS: type(o).__name__}
         if len(data) > 0:
@@ -352,7 +352,7 @@ class NdArrayTransformer(CustomTransformer):
     def to_dict(self, transformer: "Transformer", o: object) -> dict[str, Any]:
         """Convert numpy array to dictionary with shape, dtype, and data."""
         assert isinstance(o, np.ndarray)  # noqa: S101
-        return {"shape": list(o.shape), "dtype": o.dtype.str, "data": transformer.to_dict(o.ravel().tolist())}  # type: ignore[arg-type]
+        return {"shape": list(o.shape), "dtype": o.dtype.str, "data": transformer.to_dict(o.ravel().tolist())}  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     def from_dict(self, transformer: "Transformer", d: dict[str, Any]) -> object:
         """Reconstruct numpy array from dictionary."""

--- a/src/loman/util.py
+++ b/src/loman/util.py
@@ -38,8 +38,8 @@ def apply1(
 def as_iterable(xs: T | Iterable[T]) -> Iterable[T]:
     """Convert input to iterable form if not already iterable."""
     if isinstance(xs, (types.GeneratorType, list, set)):
-        return xs  # type: ignore[return-value]
-    return (xs,)  # type: ignore[return-value]
+        return xs  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+    return (xs,)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
 
 
 def apply_n(f: Callable[..., Any], *xs: Any, **kwds: Any) -> None:

--- a/src/loman/visualization.py
+++ b/src/loman/visualization.py
@@ -68,7 +68,7 @@ class NodeFormatter(ABC):
         colors = colors.lower()
         if colors == "state":
             state_cmap = cmap if isinstance(cmap, dict) else None
-            node_formatters.append(ColorByState(state_cmap))  # type: ignore[arg-type]
+            node_formatters.append(ColorByState(state_cmap))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         elif colors == "timing":
             timing_cmap = cmap if isinstance(cmap, Colormap) else None
             node_formatters.append(ColorByTiming(timing_cmap))
@@ -431,14 +431,14 @@ class GraphView:
         """Generate SVG representation of the visualization."""
         if self.viz_dot is None:
             return None
-        svg_bytes: bytes = self.viz_dot.create_svg()  # type: ignore[attr-defined]
+        svg_bytes: bytes = self.viz_dot.create_svg()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return svg_bytes.decode("utf-8")
 
     def view(self) -> None:  # pragma: no cover
         """Open the visualization in a PDF viewer."""
         assert self.viz_dot is not None  # noqa: S101
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            f.write(self.viz_dot.create_pdf())  # type: ignore[attr-defined]
+            f.write(self.viz_dot.create_pdf())  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
             if sys.platform == "win32":
                 os.startfile(f.name)  # pragma: no cover  # nosec B606  # noqa: S606
             else:


### PR DESCRIPTION
## Summary

The rhiza scaffold introduced the `ty` type checker alongside mypy. `ty` is stricter in several areas and raises errors on expressions that mypy already suppresses with `# type: ignore`. This PR adds `# ty: ignore[<code>]` inline after each existing suppression so both checkers pass without any runtime behaviour change.

## Changes

All changes are comment-only — no logic is modified.

| File | Suppression codes added |
|------|------------------------|
| `src/loman/computeengine.py` | `unresolved-attribute`, `no-matching-overload`, `invalid-assignment`, `method-assign` |
| `src/loman/nodekey.py` | `unresolved-attribute`; adds `# pragma: no cover` on two structurally unreachable branches |
| `src/loman/serialization/transformer.py` | `unresolved-attribute`, `invalid-argument-type` |
| `src/loman/util.py` | `invalid-return-type` |
| `src/loman/visualization.py` | `invalid-argument-type`, `unresolved-attribute` |

## Testing

- [ ] `make test` passes locally
- [ ] `make typecheck` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)