### PR TITLE
feat: add shell tab-completion scripts for make targets

### DIFF
--- a/.rhiza/completions/README.md
+++ b/.rhiza/completions/README.md
@@ -1,0 +1,263 @@
+# Shell Completion for Rhiza Make Targets
+
+This directory contains shell completion scripts for Bash and Zsh that provide tab-completion for make targets in Rhiza-based projects.
+
+## Features
+
+- ✅ Tab-complete all available make targets
+- ✅ Show target descriptions in Zsh
+- ✅ Complete common make variables (DRY_RUN, BUMP, ENV, etc.)
+- ✅ Works with any Rhiza-based project
+- ✅ Auto-discovers targets from Makefile and included .mk files
+
+## Installation
+
+### Bash
+
+#### Method 1: Source in your shell config
+
+Add to your `~/.bashrc` or `~/.bash_profile`:
+
+```bash
+# Rhiza make completion
+if [ -f /path/to/project/.rhiza/completions/rhiza-completion.bash ]; then
+    source /path/to/project/.rhiza/completions/rhiza-completion.bash
+fi
+```
+
+Replace `/path/to/project` with the actual path to your Rhiza project.
+
+#### Method 2: System-wide installation
+
+```bash
+# Copy to bash completion directory
+sudo cp .rhiza/completions/rhiza-completion.bash /etc/bash_completion.d/rhiza
+
+# Reload completions
+source /etc/bash_completion.d/rhiza
+```
+
+#### Method 3: User-local installation
+
+```bash
+# Create local completion directory
+mkdir -p ~/.local/share/bash-completion/completions
+
+# Copy completion script
+cp .rhiza/completions/rhiza-completion.bash ~/.local/share/bash-completion/completions/make
+
+# Reload bash
+source ~/.bashrc
+```
+
+### Zsh
+
+#### Method 1: User-local installation (Recommended)
+
+```bash
+# Create completion directory
+mkdir -p ~/.zsh/completion
+
+# Copy completion script
+cp .rhiza/completions/rhiza-completion.zsh ~/.zsh/completion/_make
+
+# Add to ~/.zshrc (if not already present)
+echo 'fpath=(~/.zsh/completion $fpath)' >> ~/.zshrc
+echo 'autoload -U compinit && compinit' >> ~/.zshrc
+
+# Reload zsh
+source ~/.zshrc
+```
+
+#### Method 2: Source directly
+
+Add to your `~/.zshrc`:
+
+```zsh
+# Rhiza make completion
+if [ -f /path/to/project/.rhiza/completions/rhiza-completion.zsh ]; then
+    source /path/to/project/.rhiza/completions/rhiza-completion.zsh
+fi
+```
+
+#### Method 3: System-wide installation
+
+```bash
+# Copy to system completion directory
+sudo cp .rhiza/completions/rhiza-completion.zsh /usr/local/share/zsh/site-functions/_make
+
+# Reload zsh
+exec zsh
+```
+
+## Usage
+
+Once installed, you can tab-complete make targets:
+
+```bash
+# Tab-complete targets
+make <TAB>
+
+# Complete with prefix
+make te<TAB>  # Expands to: make test
+
+# Complete variables
+make BUMP=<TAB>  # Shows: patch, minor, major
+
+# Works with any target
+make doc<TAB>  # Shows: docs, docker-build, docker-run, etc.
+```
+
+### Zsh Benefits
+
+In Zsh, you'll also see descriptions for targets:
+
+```bash
+make <TAB>
+# Shows:
+# test        -- run all tests
+# fmt         -- check the pre-commit hooks and the linting
+# install     -- install
+# book        -- build documentation site via zensical
+# ...
+```
+
+## Common Variables
+
+The completion scripts understand these common variables:
+
+| Variable | Values | Description |
+|----------|--------|-------------|
+| `DRY_RUN` | `1` | Preview mode without making changes |
+| `BUMP` | `patch`, `minor`, `major` | Version bump type |
+| `ENV` | `dev`, `staging`, `prod` | Target environment |
+| `COVERAGE_FAIL_UNDER` | (number) | Minimum coverage threshold |
+| `PYTHON_VERSION` | (version) | Override Python version |
+
+Example usage:
+
+```bash
+# Tab-complete after typing DRY_
+make DRY_<TAB>     # Expands to: make DRY_RUN=1
+
+# Tab-complete variable values
+make BUMP=<TAB>    # Shows: patch minor major
+
+# Combine with targets
+make bump BUMP=<TAB>
+```
+
+## Troubleshooting
+
+### Bash: Completions not working
+
+1. Check if bash-completion is installed:
+   ```bash
+   # Debian/Ubuntu
+   sudo apt-get install bash-completion
+   
+   # macOS
+   brew install bash-completion@2
+   ```
+
+2. Ensure completion is enabled in your shell:
+   ```bash
+   # Add to ~/.bashrc if not present
+   if [ -f /etc/bash_completion ]; then
+       . /etc/bash_completion
+   fi
+   ```
+
+3. Reload your shell configuration:
+   ```bash
+   source ~/.bashrc
+   ```
+
+### Zsh: Completions not working
+
+1. Check if compinit is called in your `~/.zshrc`:
+   ```zsh
+   autoload -U compinit && compinit
+   ```
+
+2. Clear the completion cache:
+   ```bash
+   rm -f ~/.zcompdump
+   compinit
+   ```
+
+3. Ensure the script is in your fpath:
+   ```zsh
+   echo $fpath
+   ```
+
+4. Reload your shell configuration:
+   ```zsh
+   source ~/.zshrc
+   ```
+
+### No targets appearing
+
+1. Ensure you're in a directory with a Makefile:
+   ```bash
+   ls -la Makefile
+   ```
+
+2. Test that make can parse the Makefile:
+   ```bash
+   make -qp 2>/dev/null | head
+   ```
+
+3. Manually source the completion script to test:
+   ```bash
+   # Bash
+   source .rhiza/completions/rhiza-completion.bash
+   
+   # Zsh
+   source .rhiza/completions/rhiza-completion.zsh
+   ```
+
+## Optional Aliases
+
+You can add shortcuts in your shell config:
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+alias m='make'
+
+# For bash:
+complete -F _rhiza_make_completion m
+
+# For zsh:
+compdef _rhiza_make m
+```
+
+Then use:
+```bash
+m te<TAB>  # Expands to: m test
+```
+
+## Technical Details
+
+### How it works
+
+1. **Target Discovery**: Parses `make -qp` output to find all targets
+2. **Description Extraction**: Looks for `##` comments after target names
+3. **Variable Detection**: Includes common Makefile variables
+4. **Dynamic Completion**: Regenerates list each time you tab
+
+### Performance
+
+- Completions are generated on-demand (when you press Tab)
+- For large Makefiles (100+ targets), there may be a small delay
+- Results are not cached to ensure targets are always current
+
+## See Also
+
+- [Tools Reference](../../docs/reference/TOOLS_REFERENCE.md) - Complete command reference
+- [Quick Reference](../../docs/guides/QUICK_REFERENCE.md) - Quick command reference
+- [Extending Rhiza](../../docs/guides/EXTENDING_RHIZA.md) - How to add custom targets
+
+---
+
+*Last updated: 2026-02-15*

--- a/.rhiza/completions/rhiza-completion.bash
+++ b/.rhiza/completions/rhiza-completion.bash
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Bash completion for Rhiza make targets
+#
+# Installation:
+#   Source this file in your ~/.bashrc or ~/.bash_profile:
+#     source /path/to/.rhiza/completions/rhiza-completion.bash
+#
+#   Or copy to bash completion directory:
+#     sudo cp .rhiza/completions/rhiza-completion.bash /etc/bash_completion.d/rhiza
+#
+
+_rhiza_make_completion() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # Check if we're in a directory with a Makefile
+    if [[ ! -f "Makefile" ]]; then
+        return 0
+    fi
+
+    # Extract make targets from Makefile and all included .mk files
+    # Looks for lines like: target: ## description
+    opts=$(make -qp 2>/dev/null | \
+           awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}' | \
+           grep -v '^Makefile$' | \
+           sort -u)
+
+    # Add common make variables that can be overridden
+    local vars="DRY_RUN=1 BUMP=patch BUMP=minor BUMP=major ENV=dev ENV=staging ENV=prod"
+    opts="$opts $vars"
+
+    # Generate completions
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+}
+
+# Register the completion function for make command
+complete -F _rhiza_make_completion make
+
+# Also complete for direct make invocation with path
+complete -F _rhiza_make_completion ./Makefile
+
+# Helpful aliases (optional - uncomment if desired)
+# alias m='make'
+# complete -F _rhiza_make_completion m

--- a/.rhiza/completions/rhiza-completion.zsh
+++ b/.rhiza/completions/rhiza-completion.zsh
@@ -1,0 +1,88 @@
+#compdef make
+# Zsh completion for Rhiza make targets
+#
+# Installation:
+#   Add this file to your fpath and ensure compinit is called:
+#
+#   Method 1 (User-local):
+#     mkdir -p ~/.zsh/completion
+#     cp .rhiza/completions/rhiza-completion.zsh ~/.zsh/completion/_make
+#     Add to ~/.zshrc:
+#       fpath=(~/.zsh/completion $fpath)
+#       autoload -U compinit && compinit
+#
+#   Method 2 (Source directly):
+#     Add to ~/.zshrc:
+#       source /path/to/.rhiza/completions/rhiza-completion.zsh
+#
+#   Method 3 (System-wide):
+#     sudo cp .rhiza/completions/rhiza-completion.zsh /usr/local/share/zsh/site-functions/_make
+#
+
+_rhiza_make() {
+    local -a targets variables
+    
+    # Check if we're in a directory with a Makefile
+    if [[ ! -f "Makefile" ]]; then
+        return 0
+    fi
+
+    # Extract make targets with descriptions
+    # Format: target:description
+    targets=(${(f)"$(
+        make -qp 2>/dev/null | \
+        awk -F':' '
+            /^# Files/,/^# Finished Make data base/ {
+                if (/^[a-zA-Z0-9_-]+:.*##/) {
+                    target=$1
+                    desc=$0
+                    sub(/^[^#]*## */, "", desc)
+                    gsub(/^[ \t]+/, "", target)
+                    print target ":" desc
+                }
+            }
+        ' | \
+        grep -v '^Makefile:' | \
+        sort -u
+    )"})
+
+    # Also get targets without descriptions
+    local -a plain_targets
+    plain_targets=(${(f)"$(
+        make -qp 2>/dev/null | \
+        awk -F':' '/^[a-zA-Z0-9_-]+:([^=]|$)/ {
+            split($1,A,/ /)
+            for(i in A) print A[i]
+        }' | \
+        grep -v '^Makefile$' | \
+        sort -u
+    )"})
+
+    # Common make variables
+    variables=(
+        'DRY_RUN=1:preview mode without making changes'
+        'BUMP=patch:bump patch version'
+        'BUMP=minor:bump minor version'
+        'BUMP=major:bump major version'
+        'ENV=dev:development environment'
+        'ENV=staging:staging environment'
+        'ENV=prod:production environment'
+        'COVERAGE_FAIL_UNDER=:minimum coverage threshold'
+        'PYTHON_VERSION=:override Python version'
+    )
+
+    # Combine all completions
+    local -a all_completions
+    all_completions=($targets $plain_targets $variables)
+
+    # Show completions with descriptions
+    _describe 'make targets' all_completions
+}
+
+# Register the completion function
+compdef _rhiza_make make
+
+# Optional: Add completion for common aliases
+# Uncomment these if you use these aliases
+# alias m='make'
+# compdef _rhiza_make m


### PR DESCRIPTION
## Summary

Adds Bash and Zsh tab-completion scripts for `make` targets in Rhiza-based projects.

## Changes

- **`.rhiza/completions/rhiza-completion.bash`** — registers `_rhiza_make_completion` via `complete -F`; discovers targets from `make -qp` output and surfaces common overridable variables (`DRY_RUN`, `BUMP`, `ENV`, etc.)
- **`.rhiza/completions/rhiza-completion.zsh`** — `compdef _rhiza_make make`; extracts targets with `##` descriptions for annotated Zsh completion and falls back to plain target names for targets without descriptions
- **`.rhiza/completions/README.md`** — installation instructions for Bash and Zsh (user-local, system-wide, and source-directly methods), usage examples, variable reference, and troubleshooting guide

## Testing

- [ ] `source .rhiza/completions/rhiza-completion.bash` and tab-complete `make <TAB>` in Bash
- [ ] Install `.rhiza/completions/rhiza-completion.zsh` and tab-complete `make <TAB>` in Zsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)