### PR TITLE
chore: update devcontainer feature versions and make install lightweight

### DIFF
--- a/.devcontainer/bootstrap.sh
+++ b/.devcontainer/bootstrap.sh
@@ -49,9 +49,13 @@ echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> ~/.bashrc
 # Add to current PATH so subsequent commands can find uv
 export PATH="$INSTALL_DIR:$PATH"
 
+# Default to a lightweight dependency set in devcontainers.
+# Override with UV_SYNC_ARGS to install different groups.
+export UV_SYNC_ARGS="${UV_SYNC_ARGS:---group lint --group test}"
+
 # Install dependencies with recovery options
 echo "📦 Installing project dependencies..."
-if ! make install; then
+if ! make install UV_SYNC_ARGS="$UV_SYNC_ARGS"; then
     error_with_recovery \
         "Dependency installation" \
         "make install failed" \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,8 @@
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers/features/copilot-cli:1": {},
-        "ghcr.io/devcontainers/features/node:1": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+        "ghcr.io/devcontainers/features/node:2": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:3": {
             "moby": false
         }
     },


### PR DESCRIPTION
## Summary

Two small improvements to the devcontainer setup: bump stale feature versions and make the default install lighter.

## Changes

- **`.devcontainer/devcontainer.json`** — bump `node` feature `1→2` and `docker-in-docker` feature `2→3`
- **`.devcontainer/bootstrap.sh`** — default `UV_SYNC_ARGS` to `--group lint --group test` so containers only install the lightweight dependency set; callers can override by setting `UV_SYNC_ARGS` before container launch

## Testing

- [ ] Open repo in a Dev Container and verify `make install` completes with only lint+test groups installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)