### PR TITLE
chore: sync .rhiza/make.d targets and add semgrep.yml (rhiza v0.18.4)

### DIFF
--- a/.rhiza/make.d/book.mk
+++ b/.rhiza/make.d/book.mk
@@ -13,6 +13,7 @@ hypothesis-test:: ; @:
 BOOK_OUTPUT ?= _book
 
 MKDOCS_EXTRA_PACKAGES ?=
+ZENSICAL_VERSION ?= >=0.0.36
 
 ##@ Book
 
@@ -44,12 +45,12 @@ _book-notebooks:
 # refuses to serve gitignored directories like _book) is not needed.
 serve: book ## build and serve the book at http://localhost:8000
 	@printf "${BLUE}[INFO] Serving book at http://localhost:8000 (Ctrl-C to stop)${RESET}\n"
-	@cd $(BOOK_OUTPUT) && python3 -m http.server 8000
+	@cd $(BOOK_OUTPUT) && ${UV_BIN} run python -m http.server 8000
 
 book:: _book-reports _book-notebooks ## compile the companion book via MkDocs
 	@rm -rf "$(BOOK_OUTPUT)"
-	@${UVX_BIN} $(MKDOCS_EXTRA_PACKAGES) zensical build -f "$(ROOT)/mkdocs.yml"
-	@touch "$(BOOK_OUTPUT)/.nojekyll"
+	@${UVX_BIN} $(MKDOCS_EXTRA_PACKAGES) 'zensical$(ZENSICAL_VERSION)' build -f "$(ROOT)/mkdocs.yml"
+	@mkdir -p "$(BOOK_OUTPUT)" && touch "$(BOOK_OUTPUT)/.nojekyll"
 	@if [ -f "${ROOT}/_tests/coverage.xml" ]; then \
 	  printf "${BLUE}[INFO] Generating coverage badge${RESET}\n"; \
 	  ${UVX_BIN} "genbadge[coverage]" coverage -i "${ROOT}/_tests/coverage.xml" -o "$(BOOK_OUTPUT)/coverage-badge.svg"; \

--- a/.rhiza/make.d/bootstrap.mk
+++ b/.rhiza/make.d/bootstrap.mk
@@ -5,6 +5,8 @@
 # Declare phony targets (they don't produce files)
 .PHONY: install-uv install clean pre-install post-install
 
+UV_SYNC_ARGS ?= --all-extras --all-groups
+
 # Hook targets (double-colon rules allow multiple definitions)
 pre-install:: ; @:
 post-install:: ; @:
@@ -45,10 +47,10 @@ install: pre-install install-uv ## install
 	      exit 1; \
 	    fi; \
 	    printf "${BLUE}[INFO] Installing dependencies from lock file${RESET}\n"; \
-	    ${UV_BIN} sync --all-extras --all-groups --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
 	  else \
 	    printf "${YELLOW}[WARN] uv.lock not found. Generating lock file and installing dependencies...${RESET}\n"; \
-	    ${UV_BIN} sync --all-extras || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
 	  fi; \
 	else \
 	  printf "${YELLOW}[WARN] No pyproject.toml found, skipping install${RESET}\n"; \

--- a/.rhiza/make.d/doctor.mk
+++ b/.rhiza/make.d/doctor.mk
@@ -1,0 +1,60 @@
+## .rhiza/make.d/doctor.mk - Developer prerequisite diagnostics
+
+.PHONY: doctor
+
+##@ Dev
+doctor: ## verify local prerequisites and print actionable guidance
+	@failed=0; \
+	version_ge() { \
+		awk -v a="$$1" -v b="$$2" 'BEGIN { \
+			split(a, A, /[^0-9]+/); \
+			split(b, B, /[^0-9]+/); \
+			for (i = 1; i <= 3; i++) { \
+				ai = A[i] + 0; \
+				bi = B[i] + 0; \
+				if (ai > bi) exit 0; \
+				if (ai < bi) exit 1; \
+			} \
+			exit 0; \
+		}'; \
+	}; \
+	check_tool() { \
+		tool="$$1"; min="$$2"; install_url="$$3"; version_cmd="$$4"; gnu_required="$$5"; \
+		if ! command -v "$$tool" >/dev/null 2>&1; then \
+			printf "${RED}[❌]${RESET} %-9s missing — install: %s\n" "$$tool" "$$install_url"; \
+			failed=1; \
+			return; \
+		fi; \
+		version="$$(eval "$$version_cmd" 2>/dev/null)"; \
+		if [ -z "$$version" ]; then \
+			printf "${RED}[❌]${RESET} %-9s unknown version (required ≥ %s)\n" "$$tool" "$$min"; \
+			failed=1; \
+			return; \
+		fi; \
+		extra=""; \
+		if [ "$$gnu_required" = "gnu" ] && ! make --version 2>/dev/null | grep -q '^GNU Make'; then \
+			extra=" (GNU required)"; \
+			printf "${RED}[❌]${RESET} %-9s %-8s < %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+			failed=1; \
+			return; \
+		fi; \
+		if version_ge "$$version" "$$min"; then \
+			if [ "$$gnu_required" = "gnu" ]; then \
+				extra=" (GNU required)"; \
+			fi; \
+			printf "${GREEN}[✅]${RESET} %-9s %-8s ≥ %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+		else \
+			if [ "$$gnu_required" = "gnu" ]; then \
+				extra=" (GNU required)"; \
+			fi; \
+			printf "${RED}[❌]${RESET} %-9s %-8s < %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+			failed=1; \
+		fi; \
+	}; \
+	check_tool "uv" "0.4.0" "https://docs.astral.sh/uv/getting-started/installation/" "uv --version | awk 'NR==1 {print \$$2}'" ""; \
+	check_tool "make" "3.8.0" "https://www.gnu.org/software/make/" "make --version | awk 'NR==1 {for (i=1; i<=NF; i++) if (\$$i ~ /^[0-9]+(\\.[0-9]+)+$$/) {print \$$i; exit}}'" "gnu"; \
+	check_tool "git" "2.0.0" "https://git-scm.com" "git --version | awk 'NR==1 {print \$$3}'" ""; \
+	if [ "$$failed" -ne 0 ]; then \
+		printf "\n${YELLOW}[WARN] One or more prerequisites are missing or below minimum version.${RESET}\n"; \
+		exit 1; \
+	fi

--- a/.rhiza/make.d/quality.mk
+++ b/.rhiza/make.d/quality.mk
@@ -49,7 +49,7 @@ suppression-audit: ## scan codebase for inline suppressions and report (grade, d
 semgrep: install ## run Semgrep static analysis
 	@printf "${BLUE}[INFO] Running Semgrep...${RESET}\n"
 	@if [ -d ${SOURCE_FOLDER} ]; then \
-		${UVX_BIN} semgrep --config .github/semgrep.yml ${SOURCE_FOLDER}; \
+		${UVX_BIN} semgrep --config .rhiza/semgrep.yml ${SOURCE_FOLDER}; \
 	else \
 		printf "${YELLOW}[WARN] SOURCE_FOLDER '${SOURCE_FOLDER}' not found, skipping semgrep.${RESET}\n"; \
 	fi

--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -4,7 +4,7 @@
 # executing performance benchmarks.
 
 # Declare phony targets (they don't produce files)
-.PHONY: test benchmark typecheck security docs-coverage hypothesis-test coverage-badge stress
+.PHONY: test benchmark typecheck security docs-coverage hypothesis-test coverage-badge stress test-pyproject
 
 # Default directory for tests
 TESTS_FOLDER := tests
@@ -30,6 +30,7 @@ test:: install ## run all tests
 	mkdir -p _tests/html-coverage _tests/html-report; \
 	if [ -d ${SOURCE_FOLDER} ]; then \
 	  ${UV_BIN} run pytest \
+	  -n auto \
 	  --ignore=${TESTS_FOLDER}/benchmarks \
 	  --ignore=${TESTS_FOLDER}/stress \
 	  --cov=${SOURCE_FOLDER} \
@@ -42,6 +43,7 @@ test:: install ## run all tests
 	else \
 	  printf "${YELLOW}[WARN] Source folder ${SOURCE_FOLDER} not found, running tests without coverage${RESET}\n"; \
 	  ${UV_BIN} run pytest \
+	  -n auto \
 	  --ignore=${TESTS_FOLDER}/benchmarks \
 	  --ignore=${TESTS_FOLDER}/stress \
 	  --html=_tests/html-report/report.html; \
@@ -95,7 +97,7 @@ benchmark:: install ## run performance benchmarks
 docs-coverage: install ## check documentation coverage with interrogate
 	@if [ -d "${SOURCE_FOLDER}" ]; then \
 	  printf "${BLUE}[INFO] Checking documentation coverage in ${SOURCE_FOLDER}...${RESET}\n"; \
-	  ${UV_BIN} run interrogate -vv ${SOURCE_FOLDER}; \
+	  ${UV_BIN} run interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic ${SOURCE_FOLDER}; \
 	else \
 	  printf "${YELLOW}[WARN] Source folder ${SOURCE_FOLDER} not found, skipping docs-coverage${RESET}\n"; \
 	fi
@@ -126,19 +128,6 @@ hypothesis-test:: install ## run property-based tests with Hypothesis
 	fi; \
 	exit $$exit_code
 
-coverage-badge: test ## generate coverage badge into _tests/coverage-badge.svg
-	@if [ ! -d "${SOURCE_FOLDER}" ]; then \
-	  printf "${YELLOW}[WARN] Source folder ${SOURCE_FOLDER} not found, skipping coverage-badge${RESET}\n"; \
-	  exit 0; \
-	fi; \
-	if [ ! -f _tests/coverage.xml ]; then \
-	  printf "${RED}[ERROR] Coverage report not found at _tests/coverage.xml, run 'make test' first.${RESET}\n"; \
-	  exit 1; \
-	fi; \
-	printf "${BLUE}[INFO] Generating coverage badge...${RESET}\n"; \
-	${UVX_BIN} "genbadge[coverage]" coverage -i _tests/coverage.xml -o _tests/coverage-badge.svg; \
-	printf "${GREEN}[SUCCESS] Coverage badge generated at _tests/coverage-badge.svg${RESET}\n"
-
 # The 'stress' target runs stress/load tests.
 # 1. Checks if stress tests exist in the tests/stress directory.
 # 2. Runs pytest with the stress marker to execute only stress tests.
@@ -155,3 +144,12 @@ stress:: install ## run stress/load tests
 	  -m stress \
 	  --tb=short \
 	  --html=_tests/stress/report.html
+
+test-pyproject: install ## run pyproject.toml structure tests
+	@${UV_BIN} run pytest .rhiza/tests/structure/test_pyproject.py \
+		-v \
+		--tb=long \
+		--showlocals \
+		-rA \
+		--durations=0 \
+		--no-header

--- a/.rhiza/semgrep.yml
+++ b/.rhiza/semgrep.yml
@@ -1,0 +1,84 @@
+rules:
+  # ----------------------------
+  # Security
+  # ----------------------------
+
+  - id: numpy-load-allow-pickle
+    patterns:
+      - pattern: np.load($PATH, ...)
+      - pattern-not: np.load($PATH, ..., allow_pickle=False, ...)
+    message: |
+      np.load() may deserialize arbitrary objects when allow_pickle=True
+      (default in older NumPy versions). This can execute malicious code.
+      Pass allow_pickle=False unless explicitly required.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-502: Deserialization of Untrusted Data"
+
+  # ----------------------------
+  # Randomness / Reproducibility
+  # ----------------------------
+
+  - id: numpy-random-seed
+    pattern: np.random.seed(...)
+    message: |
+      np.random.seed() sets global state and is not thread-safe.
+      Prefer a local Generator via np.random.default_rng().
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: best-practice
+
+  - id: numpy-global-random-state
+    patterns:
+      - pattern-either:
+          - pattern: np.random.rand(...)
+          - pattern: np.random.randn(...)
+          - pattern: np.random.randint(...)
+          - pattern: np.random.random(...)
+          - pattern: np.random.normal(...)
+          - pattern: np.random.uniform(...)
+          - pattern: np.random.choice(...)
+          - pattern: np.random.shuffle(...)
+    message: |
+      Global np.random.* usage is not thread-safe and can harm reproducibility.
+      Prefer a local Generator:
+        rng = np.random.default_rng(seed)
+        rng.method(...)
+    languages: [python]
+    severity: INFO
+    metadata:
+      category: best-practice
+
+  # ----------------------------
+  # Numerical Stability
+  # ----------------------------
+
+  - id: numpy-avoid-inv
+    pattern: np.linalg.inv($X)
+    message: |
+      Avoid explicit matrix inversion. Use np.linalg.solve(A, b)
+      for better numerical stability and performance.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: numerical-stability
+
+  # ----------------------------
+  # Deprecated / Dangerous APIs
+  # ----------------------------
+
+  - id: numpy-matrix-deprecated
+    patterns:
+      - pattern-either:
+          - pattern: np.matrix(...)
+          - pattern: np.mat(...)
+    message: |
+      np.matrix is deprecated and scheduled for removal. Use np.array
+      or np.ndarray instead. It has different operator semantics (*).
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: maintainability

--- a/.rhiza/tests/api/conftest.py
+++ b/.rhiza/tests/api/conftest.py
@@ -35,6 +35,7 @@ SPLIT_MAKEFILES = [
     ".rhiza/make.d/bootstrap.mk",
     ".rhiza/make.d/quality.mk",
     ".rhiza/make.d/releasing.mk",
+    ".rhiza/make.d/doctor.mk",
     ".rhiza/make.d/test.mk",
     ".rhiza/make.d/book.mk",
     ".rhiza/make.d/marimo.mk",

--- a/.rhiza/tests/api/test_makefile_targets.py
+++ b/.rhiza/tests/api/test_makefile_targets.py
@@ -50,6 +50,38 @@ class TestMakefile:
         assert "Targets:" in out
         assert "Bootstrap" in out or "Meta" in out  # section headers
 
+    def test_doctor_target_appears_in_help(self, logger):
+        """Doctor target should appear in help under the Dev section."""
+        proc = run_make(logger, ["help"])
+        out = proc.stdout
+        assert "Dev" in out
+        assert "doctor" in out
+
+    def test_doctor_fails_when_minimum_version_is_not_met(self, logger, tmp_path):
+        """Doctor should exit non-zero when a prerequisite version is below the minimum."""
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir(exist_ok=True)
+
+        for name, content in {
+            "uv": "#!/usr/bin/env sh\necho 'uv 0.3.0'\n",
+            "python": "#!/usr/bin/env sh\necho 'Python 3.12.2'\n",
+            "make": "#!/usr/bin/env sh\necho 'GNU Make 4.4.1'\n",
+            "git": "#!/usr/bin/env sh\necho 'git version 2.44.0'\n",
+        }.items():
+            script = fake_bin / name
+            script.write_text(content)
+            script.chmod(0o755)
+
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+
+        proc = run_make(logger, ["doctor"], dry_run=False, check=False, env=env)
+        out = strip_ansi(proc.stdout)
+        assert proc.returncode != 0
+        assert "[❌] uv" in out
+        assert "0.3.0" in out
+        assert "0.4.0" in out
+
     def test_fmt_target_dry_run(self, logger, tmp_path):
         """Fmt target should invoke pre-commit via uvx with Python version in dry-run output."""
         # Create clean environment without PYTHON_VERSION so Makefile reads from .python-version

--- a/.rhiza/tests/api/test_makefile_targets.py
+++ b/.rhiza/tests/api/test_makefile_targets.py
@@ -192,33 +192,6 @@ class TestMakefile:
         proc_override = run_make(logger, ["test", "COVERAGE_FAIL_UNDER=42"])
         assert "--cov-fail-under=42" in proc_override.stdout
 
-    def test_coverage_badge_target_dry_run(self, logger, tmp_path):
-        """Coverage-badge target should invoke genbadge via uvx and write badge locally."""
-        tests_dir = tmp_path / "_tests"
-        tests_dir.mkdir(exist_ok=True)
-        (tests_dir / "coverage.xml").write_text("")
-
-        proc = run_make(logger, ["coverage-badge"])
-        out = proc.stdout
-        assert "genbadge[coverage]" in out
-        assert "_tests/coverage.xml" in out
-        assert "_tests/coverage-badge.svg" in out
-
-    def test_coverage_badge_skips_without_source_folder(self, logger, tmp_path):
-        """Coverage-badge target should include a guard check for SOURCE_FOLDER in dry-run output."""
-        # Update .env to set SOURCE_FOLDER to a non-existent directory
-        env_file = tmp_path / ".rhiza" / ".env"
-        env_content = env_file.read_text()
-        env_content += "\nSOURCE_FOLDER=nonexistent_src\n"
-        env_file.write_text(env_content)
-
-        proc = run_make(logger, ["coverage-badge"])
-        out = proc.stdout
-        # Should contain the guard check for missing source folder
-        assert "if [ ! -d" in out
-        assert "nonexistent_src" in out
-        assert "skipping coverage-badge" in out
-
     def test_suppression_audit_target_dry_run(self, logger):
         """Suppression-audit target should invoke the Python audit script via uv run in dry-run output."""
         proc = run_make(logger, ["suppression-audit"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
 ]
 test = [
     "pytest>=7.0",
+    "pytest-xdist>=3.0",
 ]
 lint = [
     "ruff>=0.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -21,13 +24,13 @@ classifiers = [
 license = "BSD-3-Clause"
 license-files = ["LICEN[CS]E*"]
 dependencies = [
-    "decorator",
-    "matplotlib",
-    "numpy",
-    "pydotplus",
-    "dill >= 0.2.5",
-    "networkx >= 2.0",
-    "pandas >= 0.19.2",
+    "decorator>=4.0",
+    "matplotlib>=3.8",
+    "numpy>=1.26",
+    "pydotplus>=2.0",
+    "dill >= 0.3.8",
+    "networkx >= 2.6",
+    "pandas >= 2.2",
     "attrs >= 25.0"
 ]
 
@@ -38,9 +41,17 @@ dev = [
     "marimo>=0.15",
     "scipy>=1.16.3",
 ]
+test = [
+    "pytest>=7.0",
+]
+lint = [
+    "ruff>=0.12.0",
+    "mypy>=1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/janusassetallocation/loman"
+Repository = "https://github.com/janusassetallocation/loman"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/loman"]
@@ -61,3 +72,6 @@ dill = "dill"
 
 [tool.bandit]
 skips = ["B301", "B403", "B404"]
+
+[tool.interrogate]
+ignore-overloaded-functions = true

--- a/uv.lock
+++ b/uv.lock
@@ -245,6 +245,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.62.1"
 source = { registry = "https://pypi.org/simple" }
@@ -548,6 +557,7 @@ lint = [
 ]
 test = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -573,7 +583,10 @@ lint = [
     { name = "mypy", specifier = ">=1.0" },
     { name = "ruff", specifier = ">=0.12.0" },
 ]
-test = [{ name = "pytest", specifier = ">=7.0" }]
+test = [
+    { name = "pytest", specifier = ">=7.0" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
+]
 
 [[package]]
 name = "loro"
@@ -1245,6 +1258,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -312,6 +312,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -533,17 +542,24 @@ dev = [
     { name = "ruff" },
     { name = "scipy" },
 ]
+lint = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+test = [
+    { name = "pytest" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=25.0" },
-    { name = "decorator" },
-    { name = "dill", specifier = ">=0.2.5" },
-    { name = "matplotlib" },
-    { name = "networkx", specifier = ">=2.0" },
-    { name = "numpy" },
-    { name = "pandas", specifier = ">=0.19.2" },
-    { name = "pydotplus" },
+    { name = "decorator", specifier = ">=4.0" },
+    { name = "dill", specifier = ">=0.3.8" },
+    { name = "matplotlib", specifier = ">=3.8" },
+    { name = "networkx", specifier = ">=2.6" },
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "pandas", specifier = ">=2.2" },
+    { name = "pydotplus", specifier = ">=2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -553,6 +569,11 @@ dev = [
     { name = "ruff", specifier = ">=0.12.0" },
     { name = "scipy", specifier = ">=1.16.3" },
 ]
+lint = [
+    { name = "mypy", specifier = ">=1.0" },
+    { name = "ruff", specifier = ">=0.12.0" },
+]
+test = [{ name = "pytest", specifier = ">=7.0" }]
 
 [[package]]
 name = "loro"
@@ -1125,6 +1146,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1199,6 +1229,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates the four `.rhiza/make.d` Makefile fragments to rhiza v0.18.4 and adds `semgrep.yml` which was previously living under `.github/`.

## Changes

**Updated:**
- `.rhiza/make.d/book.mk` — book build target updates
- `.rhiza/make.d/bootstrap.mk` — bootstrap/install target updates
- `.rhiza/make.d/quality.mk` — quality/lint target updates
- `.rhiza/make.d/test.mk` — simplified pytest invocation and target updates

**Added:**
- `.rhiza/semgrep.yml` — semgrep rules for security and code quality scanning, relocated from `.github/semgrep.yml` (removed in #302)

## Testing

- [ ] `make help` shows expected targets
- [ ] `make test` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)