### PR TITLE
chore: update pre-commit hooks and add local guards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,22 @@ repos:
         args: ['--unsafe']
         exclude: ^recipe/meta\.yaml$
 
+  - repo: local
+    hooks:
+      - id: no-python-cache-files
+        name: Prevent committing Python cache files
+        language: fail
+        entry: Python cache files (__pycache__, .pyc, .pyo, .pyd) must not be committed. Run 'make clean' to remove them.
+        files: '(/__pycache__/|\.py[cod]$)'
+
+      - id: no-rej-files
+        name: Reject .rej files
+        entry: "bash -c 'find . -type f -name \"*.rej\" | grep -q . && { echo \"ERROR: .rej files detected\"; find . -type f -name \"*.rej\"; exit 1; } || exit 0'"
+        language: system
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.11'
+    rev: 'v0.15.14'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -26,7 +40,7 @@ repos:
         args: ["--disable", "MD013"]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.2
     hooks:
       - id: check-renovate
         args: [ "--verbose" ]
@@ -51,7 +65,7 @@ repos:
         args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.7
+    rev: 0.11.16
     hooks:
       - id: uv-lock
 
@@ -63,7 +77,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.3.3  # Use the latest release
+    rev: v0.4.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names


### PR DESCRIPTION
## Summary

Updates four pre-commit hook versions and adds two local guards that prevent common accidental commits.

## Changes

**New local hooks:**
- `no-python-cache-files` — fails if `__pycache__`, `.pyc`, `.pyo`, or `.pyd` files are staged
- `no-rej-files` — fails if any `.rej` files (left over from failed patch merges) are present

**Version bumps:**
| Hook | Before | After |
|------|--------|-------|
| `ruff-pre-commit` | v0.15.11 | v0.15.14 |
| `check-jsonschema` | 0.37.1 | 0.37.2 |
| `uv-pre-commit` | 0.11.7 | 0.11.16 |
| `rhiza-hooks` | v0.3.3 | v0.4.0 |

## Testing

- [ ] `pre-commit run --all-files` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)