### PR TITLE
test: wrap parametrize zip() argvalues in list() (#322)

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -75,14 +75,14 @@ TEST_TRANSFORMED_OBJS: list[object] = [
 ]
 
 
-@pytest.mark.parametrize(("obj", "obj_dict"), zip(TEST_OBJS, TEST_TRANSFORMED_OBJS, strict=False))
+@pytest.mark.parametrize(("obj", "obj_dict"), list(zip(TEST_OBJS, TEST_TRANSFORMED_OBJS, strict=False)))
 def test_serialization(obj, obj_dict):
     """Test serialization."""
     u = Transformer()
     assert u.to_dict(obj) == obj_dict
 
 
-@pytest.mark.parametrize(("obj", "obj_dict"), zip(TEST_OBJS, TEST_TRANSFORMED_OBJS, strict=False))
+@pytest.mark.parametrize(("obj", "obj_dict"), list(zip(TEST_OBJS, TEST_TRANSFORMED_OBJS, strict=False)))
 def test_deserialization(obj, obj_dict):
     """Test deserialization."""
     u = Transformer()


### PR DESCRIPTION
Closes #322.

## Problem
The suite emitted `PytestRemovedIn10Warning`: `test_serialization` and `test_deserialization` in `tests/test_serialization.py` passed a bare `zip(...)` iterator as `parametrize` argvalues. Passing a non-Collection iterable to `parametrize` is deprecated and is removed in pytest 10.

## Fix
Materialize the `zip` into a `list`:

```python
@pytest.mark.parametrize(("obj", "obj_dict"), list(zip(TEST_OBJS, TEST_TRANSFORMED_OBJS, strict=False)))
```

## Verification
- `make test` — **625 passed, no warnings** (previously "625 passed, 2 warnings").
- Confirmed with `pytest -W error::pytest.PytestRemovedIn10Warning` — the file passes with the deprecation promoted to an error.
- `make fmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)