### PR TITLE
refactor: break computeengine<->visualization import cycle (#316)

### DIFF
--- a/src/loman/visualization.py
+++ b/src/loman/visualization.py
@@ -7,7 +7,7 @@ import tempfile
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 import matplotlib as mpl
 import networkx as nx
@@ -16,14 +16,35 @@ import pandas as pd
 import pydotplus
 from matplotlib.colors import Colormap
 
-import loman
-
 from .consts import NodeAttributes, NodeTransformations, States
 from .graph_utils import contract_node
 from .nodekey import Name, NodeKey, is_pattern, match_pattern, to_nodekey
 
 if TYPE_CHECKING:
     from .computeengine import Computation
+
+
+@runtime_checkable
+class _ComputationLike(Protocol):
+    """Structural stand-in for :class:`~loman.computeengine.Computation`.
+
+    ``visualization`` is a lower layer than ``computeengine`` (which imports
+    :class:`GraphView`/:class:`NodeFormatter` from here), so importing the
+    top-level ``loman`` package — or ``computeengine`` — at module load would
+    create an import cycle. A nested computation stored as a node value is
+    instead detected structurally, by the attributes that identify a
+    Computation, without importing anything from the upper layer.
+    """
+
+    dag: Any
+
+    def add_node(self, *args: Any, **kwargs: Any) -> Any:
+        """Marker method present on any Computation."""
+        ...
+
+    def compute(self, *args: Any, **kwargs: Any) -> Any:
+        """Marker method present on any Computation."""
+        ...
 
 
 @dataclass
@@ -184,7 +205,7 @@ class ShapeByType(NodeFormatter):
                 return {"shape": "ellipse", "peripheries": 2}
             elif isinstance(value, dict):
                 return {"shape": "house", "peripheries": 2}
-            elif isinstance(value, loman.Computation):
+            elif isinstance(value, _ComputationLike):
                 return {"shape": "hexagon"}
             else:
                 return {"shape": "diamond"}


### PR DESCRIPTION
Closes #316.

## Problem
`src/loman/visualization.py` imported the top-level `loman` package (`import loman`) solely to reference `loman.Computation` in a single `isinstance` check inside `ShapeByType.format`. Since `computeengine` imports `GraphView`/`NodeFormatter` from `visualization`, and `loman/__init__.py` imports `computeengine`, this formed a real import cycle:

```
loman.__init__  ->  computeengine  ->  visualization  ->  loman
```

It only survived because the reference was attribute-accessed at call time rather than import time — a latent fragility and a bidirectional coupling between the two largest modules.

## Fix
Replace the package import with a `runtime_checkable` structural `Protocol` (`_ComputationLike`) that detects a nested Computation by the attributes that identify one (`dag` plus `add_node`/`compute`), without importing anything from the upper layer:

```python
@runtime_checkable
class _ComputationLike(Protocol):
    dag: Any
    def add_node(self, *args: Any, **kwargs: Any) -> Any: ...
    def compute(self, *args: Any, **kwargs: Any) -> Any: ...
```

```python
elif isinstance(value, _ComputationLike):
    return {"shape": "hexagon"}
```

`visualization.py` now has **no runtime import** of `loman` or `computeengine` — the `Computation` import remains only under `TYPE_CHECKING` for annotations — so the cycle is gone.

## Behaviour
Unchanged. A node whose value is a `Computation` still renders as a hexagon; unrelated objects fall through to `diamond`. Verified directly:
- real `Computation` → `{'shape': 'hexagon'}`
- arbitrary object → `{'shape': 'diamond'}`

## Verification
All Rhiza gates green: `make fmt`, `make typecheck` (ty accepts the `runtime_checkable` Protocol + `isinstance`), `make test` (625 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)