### PR TITLE
feat: add graph validation and execution planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 - Added type hints on ComputationFactory
 - BUGFIX: `compute_and_get_value` sets error state on exception
+- Added non-mutating graph validation and execution planning APIs with DataFrame diagnostics
 
 ## [0.5.3] (2025-06-20)
 

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -7,3 +7,4 @@ practice. Each notebook is exported as a self-contained HTML page.
 - [Interest Rate Swaps](notebooks/interest_rate_swaps.html)
 - [Portfolio](notebooks/portfolio.html)
 - [Serialization](notebooks/serialization.html)
+- [Validation and Planning](notebooks/validation_and_planning.html)

--- a/docs/notebooks/validation_and_planning.py
+++ b/docs/notebooks/validation_and_planning.py
@@ -1,0 +1,545 @@
+"""Examples for validating and planning Loman computations."""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo==0.17.6",
+#     "loman",
+# ]
+#
+# [tool.uv.sources]
+# loman = { path = "../..", editable = true }
+# ///
+
+import marimo
+
+__generated_with = "0.23.13"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Validation and execution planning
+
+    Loman can inspect a computation before running it:
+
+    - `validate()` checks the **whole graph** for cycles, missing inputs, placeholders,
+      failed nodes, and unknown executors.
+    - `plan(target)` examines only the dependencies needed for a **specific result**.
+      It shows what would run, in dependency order, without executing or changing anything.
+    - `plan()` examines the work remaining across the **whole graph**.
+
+    This notebook develops those ideas through a series of small use cases. It has no
+    controls: run it from top to bottom, then edit values or graph definitions to explore.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    from loman import Computation
+
+    def names(nodes):
+        return [str(node) for node in nodes]
+
+    def validation_summary(report):
+        return {
+            "is_valid": report.is_valid,
+            "is_ready": report.is_ready,
+            "cycles": [names(component) for component in report.cycles],
+            "placeholders": names(report.placeholders),
+            "uninitialized_inputs": names(report.uninitialized_inputs),
+            "error_nodes": names(report.error_nodes),
+            "missing_executors": [(str(node), executor) for node, executor in report.missing_executors],
+        }
+
+    def plan_summary(plan):
+        return {
+            "is_feasible": plan.is_feasible,
+            "targets": None if plan.targets is None else names(plan.targets),
+            "execution_order": names(plan.execution_order),
+            "current_nodes": names(plan.current_nodes),
+            "blocked_nodes": names(plan.blocked_nodes),
+            "executor_assignments": [(str(node), executor) for node, executor in plan.executor_assignments],
+        }
+
+    return Computation, mo, plan_summary, validation_summary
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 1. Preview work before execution
+
+    Consider an order total with three supplied inputs and three calculations. The
+    `discount` and `total` nodes share a named executor; here it points to the computation's
+    normal executor, but in a real application it could identify a process or thread pool.
+
+    Calling `plan("total")` should identify the supplied inputs as current and list the
+    calculations in the exact dependency order required to produce `total`.
+    """)
+    return
+
+
+@app.cell
+def _(Computation):
+    order = Computation()
+    order.executor_map["pricing"] = order.default_executor
+    order.add_node("quantity", value=3)
+    order.add_node("unit_price", value=12.5)
+    order.add_node("discount_rate", value=0.1)
+    order.add_node("subtotal", lambda quantity, unit_price: quantity * unit_price)
+    order.add_node(
+        "discount",
+        lambda subtotal, discount_rate: subtotal * discount_rate,
+        executor="pricing",
+    )
+    order.add_node("total", lambda subtotal, discount: subtotal - discount, executor="pricing")
+    order
+    return (order,)
+
+
+@app.cell
+def _(order, plan_summary, validation_summary):
+    order_validation_before = order.validate()
+    order_plan_before = order.plan("total")
+    {
+        "validation": validation_summary(order_validation_before),
+        "plan": plan_summary(order_plan_before),
+    }
+    return (order_plan_before,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    The graph is both structurally valid and ready. Planning did not calculate anything:
+    the three calculation nodes are still merely pending. Now execute the target and plan
+    it again.
+    """)
+    return
+
+
+@app.cell
+def _(order, order_plan_before):
+    # Depending on the first plan makes the before/after sequence explicit to Marimo.
+    _ = order_plan_before
+    order.compute("total")
+    order
+    return
+
+
+@app.cell
+def _(order):
+    order.to_df()
+    return
+
+
+@app.cell
+def _(order, plan_summary):
+    order_plan_after = order.plan("total")
+    {
+        "values": order.to_dict(),
+        "next_plan": plan_summary(order_plan_after),
+    }
+    return (order_plan_after,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    The second plan has an empty `execution_order`: `total` is already current. This makes
+    `plan()` useful as a dry-run check before an expensive calculation, and as confirmation
+    that a requested result needs no work.
+
+    ## 2. Understand selective recalculation
+
+    Changing `discount_rate` should invalidate `discount` and `total`, but not `subtotal`.
+    The next plan makes that selective recalculation visible before it happens.
+    """)
+    return
+
+
+@app.cell
+def _(order, order_plan_after):
+    _ = order_plan_after
+    order.insert("discount_rate", 0.2, force=True)
+    order
+    return
+
+
+@app.cell
+def _(order, plan_summary):
+    recalculation_plan = order.plan("total")
+    plan_summary(recalculation_plan)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    `subtotal` now appears in `current_nodes`, while only `discount` and `total` appear in
+    `execution_order`. This is the same incremental behavior that `compute("total")` will
+    follow, exposed without doing the work.
+
+    ## 3. Diagnose a missing input
+
+    A graph can be structurally valid but not ready. Here, `raw_data` is a legitimate input
+    node whose value has not yet been supplied. Validation identifies that root cause;
+    planning shows every requested node that it blocks.
+    """)
+    return
+
+
+@app.cell
+def _(Computation):
+    import statistics
+
+    pipeline = Computation()
+    pipeline.add_node("raw_data")
+    pipeline.add_node("clean_data", lambda raw_data: [value for value in raw_data if value is not None])
+    pipeline.add_node("mean", lambda clean_data: statistics.mean(clean_data))
+    pipeline
+    return (pipeline,)
+
+
+@app.cell
+def _(pipeline, plan_summary, validation_summary):
+    pipeline_validation_missing = pipeline.validate()
+    pipeline_plan_blocked = pipeline.plan("mean")
+    {
+        "validation": validation_summary(pipeline_validation_missing),
+        "plan": plan_summary(pipeline_plan_blocked),
+    }
+    return (pipeline_plan_blocked,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Notice the distinction:
+
+    - `is_valid` is `True`: the graph has a coherent structure.
+    - `is_ready` is `False`: an external value is still required.
+    - `blocked_nodes` includes `raw_data`, `clean_data`, and `mean`: none of that branch can
+      complete yet.
+
+    Supplying the input removes the blocker and produces a feasible plan.
+    """)
+    return
+
+
+@app.cell
+def _(pipeline, pipeline_plan_blocked):
+    _ = pipeline_plan_blocked
+    pipeline.insert("raw_data", [10, None, 20, 30])
+    pipeline
+    return
+
+
+@app.cell
+def _(pipeline, plan_summary):
+    pipeline_plan_ready = pipeline.plan("mean")
+    plan_summary(pipeline_plan_ready)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 4. Plan useful work in a partially broken graph
+
+    `validate()` intentionally checks the entire graph. A production computation may contain
+    an unfinished or broken branch that is unrelated to today's requested output. A targeted
+    plan answers the more practical question: **can this particular result be calculated?**
+
+    The following graph has a healthy reporting branch and an unrelated export branch with
+    a placeholder dependency.
+    """)
+    return
+
+
+@app.cell
+def _(Computation):
+    mixed = Computation()
+    mixed.add_node("sales", value=[100, 125, 150])
+    mixed.add_node("sales_total", lambda sales: sum(sales))
+    mixed.add_node("sales_report", lambda sales_total: f"Sales: {sales_total}")
+    mixed.add_node("export_result", lambda database_connection, sales_report: (database_connection, sales_report))
+    mixed
+    return (mixed,)
+
+
+@app.cell
+def _(mixed, plan_summary, validation_summary):
+    mixed_validation = mixed.validate()
+    report_plan = mixed.plan("sales_report")
+    whole_graph_plan = mixed.plan()
+    {
+        "whole_graph_validation": validation_summary(mixed_validation),
+        "sales_report_plan": plan_summary(report_plan),
+        "whole_graph_plan": plan_summary(whole_graph_plan),
+    }
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    The whole graph is invalid because `database_connection` is a placeholder, and the whole
+    graph plan marks the export branch as blocked. The targeted `sales_report` plan remains
+    feasible because that placeholder is not one of its dependencies.
+
+    This distinction is useful for large computations containing optional outputs, staged
+    development, or environment-specific integrations.
+
+    ## 5. Detect dependency cycles
+
+    Cycles are structural errors: no member can be evaluated first. Validation reports each
+    cyclic strongly connected group, while planning marks the cycle and its required
+    descendants as blocked.
+
+    Computing the target would raise an error. Validation makes the cycle visible before any
+    execution is attempted.
+    """)
+    return
+
+
+@app.cell
+def _(Computation):
+    cyclic = Computation()
+    cyclic.add_node("positions", lambda risk: risk + 1)
+    cyclic.add_node("value", lambda positions: positions * 2)
+    cyclic.add_node("risk", lambda value: value / 10)
+    cyclic.add_node("report", lambda value: f"Value: {value}")
+    cyclic
+    return (cyclic,)
+
+
+@app.cell
+def _(cyclic, plan_summary, validation_summary):
+    cycle_validation = cyclic.validate()
+    cycle_plan = cyclic.plan("report")
+    {
+        "validation": validation_summary(cycle_validation),
+        "plan": plan_summary(cycle_plan),
+    }
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 6. Use a current value as a calculation boundary
+
+    Sometimes an intermediate result is restored from a checkpoint, supplied from a cache,
+    or deliberately pinned for an experiment. Its original inputs may be unavailable, but
+    downstream work can still proceed from the current value.
+
+    Here `calibrated_model` is pinned. Planning `forecast` stops there and does not require
+    the unavailable training data behind it.
+    """)
+    return
+
+
+@app.cell
+def _(Computation):
+    checkpointed = Computation()
+    checkpointed.add_node("training_data")
+    checkpointed.add_node("calibrated_model", lambda training_data: {"mean": sum(training_data) / len(training_data)})
+    checkpointed.insert("calibrated_model", {"mean": 42.0})
+    checkpointed.pin("calibrated_model")
+    checkpointed.add_node("scenario", value=1.1)
+    checkpointed.add_node("forecast", lambda calibrated_model, scenario: calibrated_model["mean"] * scenario)
+    checkpointed
+    return (checkpointed,)
+
+
+@app.cell
+def _(checkpointed, plan_summary, validation_summary):
+    checkpoint_validation = checkpointed.validate()
+    forecast_plan = checkpointed.plan("forecast")
+    {
+        "whole_graph_validation": validation_summary(checkpoint_validation),
+        "forecast_plan": plan_summary(forecast_plan),
+    }
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Whole-graph validation still tells us that `training_data` is unavailable. The targeted
+    plan is nevertheless feasible: `calibrated_model` and `scenario` are current boundaries,
+    so only `forecast` needs to run.
+
+    ## 7. Diagnose a large computation with nested blocks
+
+    Small examples make each failure obvious. The real value of planning appears when a graph
+    is large enough that manually following edges is tedious.
+
+    The portfolio pipeline below uses reusable blocks under nested paths:
+
+    - three feed blocks normalize positions, prices, and FX data;
+    - a valuation block combines those feeds and schedules stress calculation on a named
+      executor;
+    - a reporting branch consumes the valuation result.
+
+    It also contains four realistic configuration mistakes:
+
+    1. The prices feed was added without linking its `raw` input.
+    2. The FX feed links to `inputs/fx_spots`, but the supplied node is `inputs/fx_spot`.
+    3. The valuation block requests a `quant_pool` executor that was never configured.
+    4. `report/draft` and `report/signoff` depend on one another.
+    """)
+    return
+
+
+@app.cell
+def _(Computation):
+    def make_feed_block():
+        block = Computation()
+        block.add_node("raw")
+        block.add_node("records", lambda raw: raw)
+        block.add_node("count", lambda records: len(records))
+        return block
+
+    def make_valuation_block():
+        block = Computation()
+        block.add_node("positions")
+        block.add_node("prices")
+        block.add_node("fx")
+        block.add_node("market_value", lambda positions, prices, fx: (positions, prices, fx))
+        block.add_node("stress_loss", lambda market_value: market_value, executor="quant_pool")
+        return block
+
+    portfolio = Computation()
+    portfolio.add_node("inputs/positions", value=[{"symbol": "ABC", "quantity": 100}])
+    portfolio.add_node("inputs/prices", value={"ABC": 25.0})
+    portfolio.add_node("inputs/fx_spot", value=1.25)
+
+    portfolio.add_block(
+        "feeds/positions",
+        make_feed_block(),
+        keep_values=False,
+        links={"raw": "inputs/positions"},
+    )
+    portfolio.add_block("feeds/prices", make_feed_block(), keep_values=False)
+    portfolio.add_block(
+        "feeds/fx",
+        make_feed_block(),
+        keep_values=False,
+        links={"raw": "inputs/fx_spots"},
+    )
+    portfolio.add_block(
+        "risk/equity",
+        make_valuation_block(),
+        keep_values=False,
+        links={
+            "positions": "feeds/positions/records",
+            "prices": "feeds/prices/records",
+            "fx": "feeds/fx/records",
+        },
+    )
+
+    portfolio.add_node(
+        "report/draft",
+        lambda stress_loss, signoff: (stress_loss, signoff),
+        kwds={"stress_loss": "risk/equity/stress_loss", "signoff": "report/signoff"},
+    )
+    portfolio.add_node("report/signoff", lambda draft: draft, kwds={"draft": "report/draft"})
+    portfolio.add_node("report/final", lambda draft: draft, kwds={"draft": "report/draft"})
+    portfolio
+    return (portfolio,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    The complete issue list takes one line. Instead of searching through every block, it
+    identifies the precise paths containing the root problems.
+    """)
+    return
+
+
+@app.cell
+def _(portfolio):
+    portfolio.validate().to_df()
+    return
+
+
+@app.cell
+def _(portfolio):
+    # see the cycle
+    portfolio.draw("report")
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Validation answers **what is wrong anywhere in the graph**. Planning the desired final
+    report answers **how those problems affect this output**. `blocked_by` carries each root
+    cause through the dependency graph, so the final row explains all reasons the report
+    cannot run without manually tracing an edge.
+
+    The table keeps two related concepts separate:
+
+    - `state` is Loman's existing node state (`UPTODATE`, `COMPUTABLE`, `STALE`, and so on).
+    - `plan_status` is contextual to this target: `current`, `pending`, or `blocked`.
+
+    A node can therefore be `STALE` in the graph while being `blocked` in this plan because
+    an upstream input or executor is unavailable.
+    """)
+    return
+
+
+@app.cell
+def _(portfolio):
+    portfolio.plan("report/final").to_df()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    The two tables separate diagnosis from impact:
+
+    - `feeds/prices/raw` reveals the omitted block link.
+    - `inputs/fx_spots` exposes the typo next to the existing `inputs/fx_spot` node.
+    - `risk/equity/stress_loss` names the missing executor and every downstream node it blocks.
+    - the cycle is shown once as a connected group rather than as a confusing compute-time
+      traceback.
+    - current and independently runnable nodes remain visible, making clear how far the graph
+      can proceed after each fix.
+
+    This is the intended investigation loop for a large DAG:
+
+    ```python
+    comp.validate().to_df()
+    comp.plan("desired/output").to_df()
+    ```
+
+    ## Where to use each API
+
+    | Question | API |
+    | --- | --- |
+    | Is the complete graph well formed and fully supplied? | `comp.validate()` |
+    | What would run to produce one result? | `comp.plan("result")` |
+    | Can several outputs be produced together? | `comp.plan(["a", "b"])` |
+    | What work and blockers remain anywhere in the graph? | `comp.plan()` |
+    | Has a target become current after execution? | `comp.plan("result").execution_order == ()` |
+    | Which root issue blocks each downstream node? | `comp.plan("result").to_df()` |
+
+    Try changing supplied values, inserting missing inputs, removing a cyclic dependency, or
+    unpinning the checkpointed model. Marimo will rerun the dependent cells and expose how
+    each graph change affects validation and planning.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Interest Rate Swaps: notebooks/interest_rate_swaps.html
       - Portfolio: notebooks/portfolio.html
       - Serialization: notebooks/serialization.html
+      - Validation and Planning: notebooks/validation_and_planning.html
   - Reports:
       - Overview: reports.md
       - Test Report: reports/html-report/report.html

--- a/src/loman/__init__.py
+++ b/src/loman/__init__.py
@@ -19,6 +19,7 @@ from loman.exception import (
     ValidationError,
 )
 from loman.nodekey import Name, Names, NodeKey, to_nodekey
+from loman.planning import ExecutionPlan, ValidationReport
 from loman.serialization import ComputationSerializer
 from loman.visualization import GraphView
 
@@ -31,6 +32,7 @@ __all__ = [
     "Computation",
     "ComputationFactory",  # Backward compatibility
     "ComputationSerializer",
+    "ExecutionPlan",
     "FittingError",
     "GraphView",
     "InvalidBlockTypeError",
@@ -44,6 +46,7 @@ __all__ = [
     "SerializationError",
     "States",
     "ValidationError",
+    "ValidationReport",
     "block",
     "calc_node",
     "computation_factory",

--- a/src/loman/computeengine.py
+++ b/src/loman/computeengine.py
@@ -35,6 +35,7 @@ from .exception import (
 )
 from .graph_utils import topological_sort
 from .nodekey import Name, Names, NodeKey, names_to_node_keys, node_keys_to_names, to_nodekey
+from .planning import ExecutionPlan, ValidationReport, create_execution_plan, validate_graph
 from .util import AttributeView, apply1, apply_n, as_iterable, value_eq
 from .visualization import GraphView, NodeFormatter
 
@@ -979,9 +980,32 @@ class Computation:
             for n in self.dag.predecessors(node_key):
                 if not self.dag.has_node(n):
                     return  # pragma: no cover
-                if self.dag.nodes[n][NodeAttributes.STATE] != States.UPTODATE:
+                if self.dag.nodes[n][NodeAttributes.STATE] not in (States.UPTODATE, States.PINNED):
                     return
             self._set_state(node_key, States.COMPUTABLE)
+
+    def validate(self) -> ValidationReport:
+        """Inspect the entire graph for structural and readiness problems.
+
+        Validation does not execute functions or mutate the computation.
+        """
+        return validate_graph(self.dag, self.executor_map)
+
+    def plan(self, targets: Name | Names | None = None) -> ExecutionPlan:
+        """Describe the work needed to compute one or more targets.
+
+        Passing ``None`` plans the whole graph. Planning does not execute
+        functions or mutate the computation.
+
+        :param targets: Target node, list of target nodes, or ``None`` for all nodes.
+        """
+        target_node_keys = None if targets is None else names_to_node_keys(targets)
+        if target_node_keys is not None:
+            for node_key in target_node_keys:
+                if not self.dag.has_node(node_key):
+                    msg = f"Node {node_key} does not exist"
+                    raise NonExistentNodeException(msg)
+        return create_execution_plan(self.dag, self.executor_map, target_node_keys)
 
     def _get_parameter_data(self, node_key: NodeKey) -> Iterable[_ParameterItem]:
         """Get all parameter data for a node's function call."""
@@ -1128,8 +1152,9 @@ class Computation:
                 raise ValidationError(msg)
 
         ancestors.add(node_key)
+        g = g.subgraph(ancestors).copy()
         nodes_sorted = topological_sort(g)
-        return [n for n in nodes_sorted if n in ancestors]
+        return list(nodes_sorted)
 
     def _get_calc_node_names(self, name: Name) -> Names:
         """Get node names that need to be computed for a target node."""

--- a/src/loman/planning.py
+++ b/src/loman/planning.py
@@ -1,0 +1,252 @@
+"""Non-mutating validation and execution planning for computation graphs."""
+
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass
+
+import networkx as nx
+import pandas as pd
+
+from .consts import NodeAttributes, States
+from .nodekey import NodeKey
+
+_CURRENT_STATES = {States.UPTODATE, States.PINNED}
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Structural and readiness findings for a computation graph."""
+
+    cycles: tuple[tuple[NodeKey, ...], ...]
+    placeholders: tuple[NodeKey, ...]
+    uninitialized_inputs: tuple[NodeKey, ...]
+    error_nodes: tuple[NodeKey, ...]
+    missing_executors: tuple[tuple[NodeKey, str], ...]
+
+    @property
+    def is_valid(self) -> bool:
+        """Return whether the graph is structurally valid."""
+        return not self.cycles and not self.placeholders and not self.missing_executors
+
+    @property
+    def is_ready(self) -> bool:
+        """Return whether the graph is valid and has all required inputs."""
+        return self.is_valid and not self.uninitialized_inputs and not self.error_nodes
+
+    def to_df(self) -> pd.DataFrame:
+        """Return validation findings as one row per issue."""
+        rows: list[dict[str, str]] = []
+        for component in self.cycles:
+            nodes = ", ".join(str(node) for node in component)
+            rows.append({"issue": "cycle", "node": nodes, "detail": f"Dependency cycle: {nodes}"})
+        rows.extend(
+            {"issue": "placeholder", "node": str(node), "detail": "Node has no definition"}
+            for node in self.placeholders
+        )
+        rows.extend(
+            {"issue": "uninitialized_input", "node": str(node), "detail": "Input value has not been supplied"}
+            for node in self.uninitialized_inputs
+        )
+        rows.extend(
+            {"issue": "error", "node": str(node), "detail": "Previous calculation failed"} for node in self.error_nodes
+        )
+        rows.extend(
+            {
+                "issue": "missing_executor",
+                "node": str(node),
+                "detail": f"Executor {executor_name!r} is not configured",
+            }
+            for node, executor_name in self.missing_executors
+        )
+        return pd.DataFrame(rows, columns=["issue", "node", "detail"])
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """A non-mutating description of work required by a computation."""
+
+    targets: tuple[NodeKey, ...] | None
+    execution_order: tuple[NodeKey, ...]
+    current_nodes: tuple[NodeKey, ...]
+    blocked_nodes: tuple[NodeKey, ...]
+    node_states: tuple[tuple[NodeKey, States], ...]
+    blocked_by: tuple[tuple[NodeKey, tuple[NodeKey, ...]], ...]
+    blocker_reasons: tuple[tuple[NodeKey, str], ...]
+    executor_assignments: tuple[tuple[NodeKey, str], ...]
+    validation: ValidationReport
+
+    @property
+    def is_feasible(self) -> bool:
+        """Return whether all requested targets can be brought up to date."""
+        return self.validation.is_ready and not self.blocked_nodes
+
+    def to_df(self) -> pd.DataFrame:
+        """Return current, runnable, and blocked nodes as an execution table."""
+        order = {node: index + 1 for index, node in enumerate(self.execution_order)}
+        executors = dict(self.executor_assignments)
+        states = dict(self.node_states)
+        blocked_by = dict(self.blocked_by)
+        reasons = dict(self.blocker_reasons)
+        rows = []
+        for node in (*self.current_nodes, *self.execution_order, *self.blocked_nodes):
+            blockers = blocked_by.get(node, ())
+            blocker_details = tuple(dict.fromkeys(reasons[blocker] for blocker in blockers))
+            plan_status = "blocked" if blockers else "current" if node in self.current_nodes else "pending"
+            rows.append(
+                {
+                    "node": str(node),
+                    "state": states[node],
+                    "plan_status": plan_status,
+                    "order": order.get(node),
+                    "executor": executors.get(node),
+                    "blocked_by": ", ".join(str(blocker) for blocker in blockers) or None,
+                    "reason": "; ".join(blocker_details) or None,
+                }
+            )
+        return pd.DataFrame(
+            rows,
+            columns=["node", "state", "plan_status", "order", "executor", "blocked_by", "reason"],
+        ).set_index("node")
+
+
+def _ordered_nodes(dag: nx.DiGraph, nodes: Collection[NodeKey]) -> tuple[NodeKey, ...]:
+    """Return *nodes* in graph insertion order."""
+    return tuple(node for node in dag.nodes if node in nodes)
+
+
+def _find_cycles(dag: nx.DiGraph, nodes: Collection[NodeKey]) -> tuple[tuple[NodeKey, ...], ...]:
+    """Return cyclic strongly connected components in graph insertion order."""
+    node_order = {node: index for index, node in enumerate(dag.nodes)}
+    graph = dag.subgraph(nodes)
+    components = []
+    for component in nx.strongly_connected_components(graph):
+        if len(component) > 1 or any(graph.has_edge(node, node) for node in component):
+            components.append(tuple(sorted(component, key=node_order.__getitem__)))
+    components.sort(key=lambda component: node_order[component[0]])
+    return tuple(components)
+
+
+def validate_graph(
+    dag: nx.DiGraph,
+    executor_map: Mapping[str, object],
+    *,
+    nodes: Collection[NodeKey] | None = None,
+    executor_nodes: Collection[NodeKey] | None = None,
+) -> ValidationReport:
+    """Inspect a graph, or a subset of it, without changing it."""
+    selected = set(dag.nodes if nodes is None else nodes)
+    checked_executors = selected if executor_nodes is None else set(executor_nodes)
+
+    placeholders: set[NodeKey] = set()
+    uninitialized_inputs: set[NodeKey] = set()
+    error_nodes: set[NodeKey] = set()
+    missing_executors: list[tuple[NodeKey, str]] = []
+
+    for node_key in dag.nodes:
+        if node_key not in selected:
+            continue
+        node = dag.nodes[node_key]
+        state = node.get(NodeAttributes.STATE)
+        if state == States.PLACEHOLDER:
+            placeholders.add(node_key)
+        elif state != States.ERROR and state not in _CURRENT_STATES and node.get(NodeAttributes.FUNC) is None:
+            uninitialized_inputs.add(node_key)
+        if state == States.ERROR:
+            error_nodes.add(node_key)
+
+        executor_name = node.get(NodeAttributes.EXECUTOR)
+        if (
+            node_key in checked_executors
+            and node.get(NodeAttributes.FUNC) is not None
+            and executor_name is not None
+            and executor_name not in executor_map
+        ):
+            missing_executors.append((node_key, executor_name))
+
+    return ValidationReport(
+        cycles=_find_cycles(dag, selected),
+        placeholders=_ordered_nodes(dag, placeholders),
+        uninitialized_inputs=_ordered_nodes(dag, uninitialized_inputs),
+        error_nodes=_ordered_nodes(dag, error_nodes),
+        missing_executors=tuple(missing_executors),
+    )
+
+
+def _select_required_nodes(dag: nx.DiGraph, targets: Sequence[NodeKey]) -> tuple[set[NodeKey], set[NodeKey]]:
+    """Select target dependencies, stopping traversal at nodes with current values."""
+    selected: set[NodeKey] = set()
+    current: set[NodeKey] = set()
+    to_visit = list(reversed(targets))
+
+    while to_visit:
+        node_key = to_visit.pop()
+        if node_key in selected:
+            continue
+        selected.add(node_key)
+        if dag.nodes[node_key].get(NodeAttributes.STATE) in _CURRENT_STATES:
+            current.add(node_key)
+            continue
+        to_visit.extend(reversed(list(dag.predecessors(node_key))))
+
+    return selected, current
+
+
+def create_execution_plan(
+    dag: nx.DiGraph,
+    executor_map: Mapping[str, object],
+    targets: Sequence[NodeKey] | None,
+) -> ExecutionPlan:
+    """Build a deterministic execution plan without running or mutating nodes."""
+    plan_targets = tuple(dag.nodes) if targets is None else tuple(dict.fromkeys(targets))
+    selected, current = _select_required_nodes(dag, plan_targets)
+    pending = selected - current
+    validation = validate_graph(dag, executor_map, nodes=selected, executor_nodes=pending)
+
+    blocker_reasons: dict[NodeKey, str] = {}
+    blocker_reasons.update((node, "Node has no definition") for node in validation.placeholders)
+    blocker_reasons.update((node, "Input value has not been supplied") for node in validation.uninitialized_inputs)
+    blocker_reasons.update((node, "Previous calculation failed") for node in validation.error_nodes)
+    for component in validation.cycles:
+        detail = f"Dependency cycle: {', '.join(str(node) for node in component)}"
+        blocker_reasons.update((node, detail) for node in component)
+    blocker_reasons.update(
+        (node, f"Executor {executor_name!r} is not configured") for node, executor_name in validation.missing_executors
+    )
+
+    pending_graph = dag.subgraph(pending)
+    blocked_by: dict[NodeKey, set[NodeKey]] = {node: {node} for node in blocker_reasons if node in pending}
+    for blocker in blocker_reasons:
+        if blocker in pending:
+            for descendent in nx.descendants(pending_graph, blocker):
+                blocked_by.setdefault(descendent, set()).add(blocker)
+
+    blocked = set(blocked_by)
+    node_order = {node: index for index, node in enumerate(dag.nodes)}
+
+    runnable = pending - blocked
+    runnable_graph = dag.subgraph(runnable)
+    execution_order = tuple(nx.topological_sort(runnable_graph))
+    assignments = tuple(
+        (
+            node_key,
+            "default"
+            if dag.nodes[node_key].get(NodeAttributes.EXECUTOR) is None
+            else dag.nodes[node_key][NodeAttributes.EXECUTOR],
+        )
+        for node_key in execution_order
+    )
+
+    return ExecutionPlan(
+        targets=None if targets is None else tuple(dict.fromkeys(targets)),
+        execution_order=execution_order,
+        current_nodes=_ordered_nodes(dag, current),
+        blocked_nodes=_ordered_nodes(dag, blocked),
+        node_states=tuple((node, dag.nodes[node][NodeAttributes.STATE]) for node in dag.nodes if node in selected),
+        blocked_by=tuple(
+            (node, tuple(sorted(blocked_by[node], key=node_order.__getitem__)))
+            for node in dag.nodes
+            if node in blocked_by
+        ),
+        blocker_reasons=tuple((node, blocker_reasons[node]) for node in dag.nodes if node in blocker_reasons),
+        executor_assignments=assignments,
+        validation=validation,
+    )

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,387 @@
+"""Tests for graph validation and non-mutating execution planning."""
+
+from concurrent.futures import Executor
+
+import pandas as pd
+import pytest
+
+from loman import Computation, ExecutionPlan, NonExistentNodeError, States, ValidationReport
+from loman.consts import NodeAttributes
+from loman.nodekey import NodeKey, to_nodekey
+
+
+class FailOnSubmitExecutor(Executor):
+    """Executor that fails if planning accidentally submits work."""
+
+    def submit(self, fn, /, *args, **kwargs):
+        """Reject submitted work."""
+        raise AssertionError
+
+    def shutdown(self, wait=True, *, cancel_futures=False):
+        """Shut down without resources to release."""
+
+
+def test_validate_empty_graph():
+    """An empty graph is valid and ready."""
+    report = Computation().validate()
+
+    assert isinstance(report, ValidationReport)
+    assert report.is_valid
+    assert report.is_ready
+    assert report.cycles == ()
+    assert report.placeholders == ()
+    assert report.uninitialized_inputs == ()
+    assert report.error_nodes == ()
+    assert report.missing_executors == ()
+
+
+def test_validate_reports_graph_problems_in_insertion_order():
+    """Validation reports structural and readiness findings without raising."""
+    comp = Computation()
+    comp.add_node("missing_input")
+    comp.add_node("uses_placeholder", lambda placeholder: placeholder)
+    comp.add_node("bad_executor", lambda: 1, executor="missing")
+    comp.add_node("error", lambda: 1 / 0)
+    comp.compute("error")
+    comp.add_node("cycle_a", lambda cycle_b: cycle_b)
+    comp.add_node("cycle_b", lambda cycle_a: cycle_a)
+
+    report = comp.validate()
+
+    assert not report.is_valid
+    assert not report.is_ready
+    assert report.placeholders == (to_nodekey("placeholder"),)
+    assert report.uninitialized_inputs == (to_nodekey("missing_input"),)
+    assert report.error_nodes == (to_nodekey("error"),)
+    assert report.missing_executors == ((to_nodekey("bad_executor"), "missing"),)
+    assert report.cycles == ((to_nodekey("cycle_a"), to_nodekey("cycle_b")),)
+
+
+def test_validate_distinguishes_valid_from_ready():
+    """Missing supplied inputs affect readiness but not structural validity."""
+    comp = Computation()
+    comp.add_node("input")
+    comp.add_node("output", lambda input: input)
+
+    report = comp.validate()
+
+    assert report.is_valid
+    assert not report.is_ready
+    assert report.uninitialized_inputs == (to_nodekey("input"),)
+
+
+def test_validation_to_df_has_one_row_per_issue():
+    """Validation findings are available as a compact issue table."""
+    comp = Computation()
+    comp.add_node("input")
+    comp.add_node("uses_placeholder", lambda absent: absent)
+    comp.add_node("bad_executor", lambda: 1, executor="gpu")
+    comp.add_node("cycle_a", lambda cycle_b: cycle_b)
+    comp.add_node("cycle_b", lambda cycle_a: cycle_a)
+
+    result = comp.validate().to_df()
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["issue", "node", "detail"]
+    assert result["issue"].tolist() == [
+        "cycle",
+        "placeholder",
+        "uninitialized_input",
+        "missing_executor",
+    ]
+    assert result.loc[result["issue"] == "cycle", "node"].item() == "cycle_a, cycle_b"
+    assert result.loc[result["issue"] == "missing_executor", "detail"].item() == "Executor 'gpu' is not configured"
+
+
+def test_empty_validation_to_df_has_stable_columns():
+    """A valid graph returns an empty DataFrame with a useful schema."""
+    result = Computation().validate().to_df()
+
+    assert result.empty
+    assert list(result.columns) == ["issue", "node", "detail"]
+
+
+def test_plan_orders_pending_nodes_and_records_executors():
+    """A target plan lists required calculations in dependency order."""
+    named_executor = FailOnSubmitExecutor()
+    comp = Computation(default_executor=FailOnSubmitExecutor(), executor_map={"io": named_executor})
+    comp.add_node("input", value=2)
+    comp.add_node("double", lambda input: input * 2, executor="io")
+    comp.add_node("total", lambda double: double + 1)
+
+    plan = comp.plan("total")
+
+    assert isinstance(plan, ExecutionPlan)
+    assert plan.is_feasible
+    assert plan.targets == (to_nodekey("total"),)
+    assert plan.execution_order == (to_nodekey("double"), to_nodekey("total"))
+    assert plan.current_nodes == (to_nodekey("input"),)
+    assert plan.blocked_nodes == ()
+    assert plan.executor_assignments == ((to_nodekey("double"), "io"), (to_nodekey("total"), "default"))
+
+
+def test_plan_multiple_targets_is_deterministic_and_deduplicated():
+    """Multiple targets share work and preserve deterministic graph order."""
+    comp = Computation()
+    comp.add_node("input", value=2)
+    comp.add_node("left", lambda input: input + 1)
+    comp.add_node("right", lambda input: input * 2)
+
+    plan = comp.plan(["right", "left", "right"])
+
+    assert plan.targets == (to_nodekey("right"), to_nodekey("left"))
+    assert plan.execution_order == (to_nodekey("left"), to_nodekey("right"))
+    assert plan.current_nodes == (to_nodekey("input"),)
+
+
+def test_plan_empty_targets_has_no_work():
+    """An empty target list produces an empty feasible plan."""
+    comp = Computation()
+    comp.add_node("unused")
+
+    plan = comp.plan([])
+
+    assert plan.is_feasible
+    assert plan.targets == ()
+    assert plan.execution_order == ()
+    assert plan.current_nodes == ()
+    assert plan.blocked_nodes == ()
+
+
+def test_plan_none_inspects_all_branches_and_keeps_runnable_work():
+    """A whole-graph plan reports blocked work while retaining independent work."""
+    comp = Computation()
+    comp.add_node("ready", lambda: 1)
+    comp.add_node("missing")
+    comp.add_node("blocked", lambda missing: missing + 1)
+
+    plan = comp.plan()
+
+    assert not plan.is_feasible
+    assert plan.targets is None
+    assert plan.execution_order == (to_nodekey("ready"),)
+    assert plan.blocked_nodes == (to_nodekey("missing"), to_nodekey("blocked"))
+    assert plan.validation.uninitialized_inputs == (to_nodekey("missing"),)
+
+
+def test_target_plan_ignores_unrelated_cycle_and_placeholder():
+    """Problems outside a target's dependency slice do not block its plan."""
+    comp = Computation()
+    comp.add_node("input", value=1)
+    comp.add_node("output", lambda input: input + 1)
+    comp.add_node("cycle_a", lambda cycle_b: cycle_b)
+    comp.add_node("cycle_b", lambda cycle_a: cycle_a)
+    comp.add_node("unrelated", lambda absent: absent)
+
+    plan = comp.plan("output")
+
+    assert plan.is_feasible
+    assert plan.execution_order == (to_nodekey("output"),)
+    assert plan.validation.cycles == ()
+    assert plan.validation.placeholders == ()
+
+    comp.compute("output")
+    assert comp.value("output") == 2
+
+
+def test_plan_propagates_blockers_to_required_descendants():
+    """Missing inputs block every required downstream calculation."""
+    comp = Computation()
+    comp.add_node("input")
+    comp.add_node("middle", lambda input: input + 1)
+    comp.add_node("output", lambda middle: middle + 1)
+
+    plan = comp.plan("output")
+
+    assert not plan.is_feasible
+    assert plan.execution_order == ()
+    assert plan.blocked_nodes == (
+        to_nodekey("input"),
+        to_nodekey("middle"),
+        to_nodekey("output"),
+    )
+    assert dict(plan.blocked_by) == {
+        to_nodekey("input"): (to_nodekey("input"),),
+        to_nodekey("middle"): (to_nodekey("input"),),
+        to_nodekey("output"): (to_nodekey("input"),),
+    }
+
+
+def test_plan_to_df_explains_status_order_and_root_blockers():
+    """The plan table combines runnable work with downstream root causes."""
+    comp = Computation(executor_map={"io": FailOnSubmitExecutor()})
+    comp.add_node("current", value=1)
+    comp.add_node("runnable", lambda current: current + 1, executor="io")
+    comp.add_node("missing")
+    comp.add_node("blocked", lambda missing: missing + 1)
+    comp.add_node("target", lambda runnable, blocked: runnable + blocked)
+
+    result = comp.plan("target").to_df()
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["state", "plan_status", "order", "executor", "blocked_by", "reason"]
+    assert result.loc["current", "state"] == States.UPTODATE
+    assert result.loc["current", "plan_status"] == "current"
+    assert result.loc["runnable", "state"] == States.COMPUTABLE
+    assert result.loc["runnable", "plan_status"] == "pending"
+    assert result.loc["runnable", "order"] == 1
+    assert result.loc["runnable", "executor"] == "io"
+    assert result.loc["missing", "state"] == States.UNINITIALIZED
+    assert result.loc["missing", "plan_status"] == "blocked"
+    assert result.loc["target", "blocked_by"] == "missing"
+    assert result.loc["target", "reason"] == "Input value has not been supplied"
+
+
+def test_plan_tracks_multiple_root_blockers():
+    """A downstream node reports every independent root cause that reaches it."""
+    comp = Computation()
+    comp.add_node("missing_a")
+    comp.add_node("missing_b")
+    comp.add_node("left", lambda missing_a: missing_a)
+    comp.add_node("right", lambda missing_b: missing_b)
+    comp.add_node("output", lambda left, right: left + right)
+
+    plan = comp.plan("output")
+
+    assert dict(plan.blocked_by)[to_nodekey("output")] == (
+        to_nodekey("missing_a"),
+        to_nodekey("missing_b"),
+    )
+    assert plan.to_df().loc["output", "blocked_by"] == "missing_a, missing_b"
+
+
+def test_plan_reports_missing_executor_only_when_work_is_pending():
+    """A missing named executor blocks pending work but not a current value."""
+    comp = Computation()
+    comp.add_node("output", lambda: 1, executor="missing")
+
+    pending_plan = comp.plan("output")
+    assert not pending_plan.is_feasible
+    assert pending_plan.blocked_nodes == (to_nodekey("output"),)
+    assert pending_plan.validation.missing_executors == ((to_nodekey("output"), "missing"),)
+
+    comp.insert("output", 1)
+    current_plan = comp.plan("output")
+    assert current_plan.is_feasible
+    assert current_plan.validation.missing_executors == ()
+
+
+def test_plan_stops_at_current_and_pinned_nodes():
+    """Current values form boundaries even when their ancestors are unavailable."""
+    comp = Computation()
+    comp.add_node("unavailable")
+    comp.add_node("cached", lambda unavailable: unavailable)
+    comp.insert("cached", 10)
+    comp.pin("cached")
+    comp.add_node("output", lambda cached: cached + 1)
+
+    plan = comp.plan("output")
+
+    assert plan.is_feasible
+    assert plan.current_nodes == (to_nodekey("cached"),)
+    assert plan.execution_order == (to_nodekey("output"),)
+    assert to_nodekey("unavailable") not in plan.validation.uninitialized_inputs
+
+
+def test_whole_graph_plan_does_not_propagate_blocker_through_current_node():
+    """A current node prevents its unavailable ancestor from blocking descendants."""
+    comp = Computation()
+    comp.add_node("unavailable")
+    comp.add_node("cached", lambda unavailable: unavailable)
+    comp.insert("cached", 10)
+    comp.add_node("output", lambda cached: cached + 1)
+
+    plan = comp.plan()
+
+    assert not plan.is_feasible
+    assert plan.execution_order == (to_nodekey("output"),)
+    assert plan.blocked_nodes == (to_nodekey("unavailable"),)
+
+
+def test_pinned_predecessor_can_be_computed_downstream():
+    """Pinned values satisfy downstream dependencies during real execution."""
+    comp = Computation()
+    comp.add_node("input", value=1)
+    comp.pin("input")
+    comp.add_node("output", lambda input: input + 1)
+
+    comp.compute("output")
+
+    assert comp.state("output") == States.UPTODATE
+    assert comp.value("output") == 2
+
+
+def test_plan_supports_non_string_scalar_names():
+    """A hashable tuple remains a scalar node name rather than a target list."""
+    name = ("tuple", 1)
+    comp = Computation()
+    comp.add_node(name, lambda: 1)
+
+    plan = comp.plan(name)
+
+    assert plan.targets == (NodeKey((name,)),)
+    assert plan.execution_order == (NodeKey((name,)),)
+
+
+def test_plan_unknown_target_raises():
+    """Planning a missing target uses the public missing-node exception."""
+    with pytest.raises(NonExistentNodeError, match="Node absent does not exist"):
+        Computation().plan("absent")
+
+
+def test_plan_does_not_execute_convert_or_mutate():
+    """Planning is observational even when nodes have executable behavior."""
+    calls = []
+
+    def calculate():
+        calls.append("calculate")
+        return 1
+
+    def convert(value):
+        calls.append("convert")
+        return value
+
+    comp = Computation(default_executor=FailOnSubmitExecutor())
+    comp.add_node("output", calculate, converter=convert)
+    state_before = comp.state("output")
+    value_before = comp.value("output")
+    timing_before = comp.get_timing("output")
+    state_map_before = {state: nodes.copy() for state, nodes in comp._state_map.items()}
+
+    comp.validate()
+    plan = comp.plan("output")
+
+    assert plan.is_feasible
+    assert calls == []
+    assert comp.state("output") == state_before
+    assert comp.value("output") == value_before
+    assert comp.get_timing("output") == timing_before
+    assert comp._state_map == state_map_before
+    assert comp.dag.nodes[to_nodekey("output")][NodeAttributes.CONVERTER] is convert
+
+
+def test_plan_error_node_blocks_target():
+    """An existing error is reported as a blocker until recalculated or replaced."""
+    comp = Computation()
+    comp.add_node("error", lambda: 1 / 0)
+    comp.add_node("output", lambda error: error)
+    comp.compute("output")
+
+    plan = comp.plan("output")
+
+    assert not plan.is_feasible
+    assert plan.validation.error_nodes == (to_nodekey("error"),)
+    assert plan.blocked_nodes == (to_nodekey("error"), to_nodekey("output"))
+
+
+def test_plan_self_loop_is_blocked():
+    """Self-loops are reported as cycles rather than topologically sorted."""
+    comp = Computation()
+    comp.add_node("loop", lambda loop: loop)
+
+    plan = comp.plan("loop")
+
+    assert not plan.is_feasible
+    assert plan.validation.cycles == ((to_nodekey("loop"),),)
+    assert plan.blocked_nodes == (to_nodekey("loop"),)
+    assert plan.execution_order == ()


### PR DESCRIPTION
## Summary

- add non-mutating `Computation.validate()` and `Computation.plan()` APIs
- report cycles, placeholders, missing inputs, failed nodes, missing executors, execution order, and current-value boundaries
- propagate root blockers to downstream nodes and expose issue-oriented and node-oriented DataFrame diagnostics
- add a linear Marimo notebook covering selective recalculation, partial graphs, cycles, pinned boundaries, and a larger nested-block investigation

## Basic usage

```python
from loman import Computation

comp = Computation()
comp.add_node("input", value=3)
comp.add_node("double", lambda input: input * 2)
comp.add_node("result", lambda double: double + 1)

validation = comp.validate()
plan = comp.plan("result")

print(validation.is_ready)
print(plan.is_feasible)
print(plan.execution_order)
plan.to_df()
```

Representative output:

```text
True
True
(NodeKey('double'), NodeKey('result'))

                       state plan_status  order executor blocked_by reason
node
input        States.UPTODATE     current    NaN      NaN       None   None
double     States.COMPUTABLE     pending    1.0  default       None   None
result  States.UNINITIALIZED     pending    2.0  default       None   None
```

`state` is the existing Loman node state. `plan_status` is contextual to the requested target: `current`, `pending`, or `blocked`.

## Diagnosing blockers

```python
comp = Computation()
comp.add_node("input")
comp.add_node("double", lambda input: input * 2)
comp.add_node("result", lambda double: double + 1)

comp.validate().to_df()
comp.plan("result").to_df()
```

Representative validation output:

```text
              issue  node                            detail
uninitialized_input input Input value has not been supplied
```

Representative plan output:

```text
                       state plan_status order executor blocked_by                             reason
node
input   States.UNINITIALIZED     blocked  None     None      input  Input value has not been supplied
double  States.UNINITIALIZED     blocked  None     None      input  Input value has not been supplied
result  States.UNINITIALIZED     blocked  None     None      input  Input value has not been supplied
```

For larger graphs, `blocked_by` carries all root causes to affected descendants. The notebook demonstrates the intended two-line investigation flow against nested blocks with omitted and mistyped links, an unavailable executor, and a downstream cycle:

```python
comp.validate().to_df()
comp.plan("report/final").to_df()
```

## API behavior

- `validate()` always inspects the complete graph and returns findings rather than raising.
- `plan(target)` inspects only the dependency slice needed for that target.
- `plan([target_a, target_b])` combines shared work deterministically.
- `plan()` describes work and blockers across the complete graph.
- planning never calls node functions, converters, or executors and does not mutate state.
- `UPTODATE` and `PINNED` values form dependency boundaries.

## Backward compatibility

This is an additive feature:

- no existing public method signatures or return types change
- `ValidationReport` and `ExecutionPlan` are new root-level exports
- existing computation and serialization APIs remain unchanged

Two existing execution edge cases are corrected without changing the public API:

- a `PINNED` predecessor now correctly satisfies a downstream dependency
- targeted `compute("output")` no longer fails because of an unrelated cycle elsewhere in the graph

Both changes align execution with existing documented selective-computation and pinning semantics.

## Verification

- `661 passed`
- `100%` source coverage, including `src/loman/planning.py`
- Ruff lint and formatting checks pass
- `ty check src/loman/planning.py` passes
- `docs/notebooks/validation_and_planning.py` executes successfully
- all repository pre-commit hooks pass
