### PR TITLE
feat: allow computing blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [unreleased]
+- Allow `Computation.compute` to compute one or more blocks
 - Added type hints on ComputationFactory
 - BUGFIX: `compute_and_get_value` sets error state on exception
 

--- a/src/loman/computeengine.py
+++ b/src/loman/computeengine.py
@@ -1137,7 +1137,7 @@ class Computation:
         return node_keys_to_names(self._get_calc_node_keys(node_key))
 
     def compute(self, name: Name | Iterable[Name], raise_exceptions: bool = False) -> None:
-        """Compute a node and all necessary predecessors.
+        """Compute a node or block and all necessary predecessors.
 
         Following the computation, if successful, the target node, and all necessary ancestors that were not already
         UPTODATE will have been calculated and set to UPTODATE. Any node that did not need to be calculated will not
@@ -1148,20 +1148,26 @@ class Computation:
         will proceed as far as it can, until no more nodes that would be required to calculate the target are
         COMPUTABLE.
 
-        :param name: Name of the node to compute
+        A block name computes every node below that path. Multiple node and block
+        names may be supplied in a list or generator.
+
+        :param name: Name of the node or block to compute
         :param raise_exceptions: Whether to pass exceptions raised by node computations back to the caller
         :type raise_exceptions: Boolean, default False
         """
-        calc_nodes: set[NodeKey] | list[NodeKey]
-        if isinstance(name, (types.GeneratorType, list)):
-            calc_nodes = set()
-            for name0 in name:
-                node_key = to_nodekey(name0)
-                for n in self._get_calc_node_keys(node_key):
-                    calc_nodes.add(n)
-        else:
-            node_key = to_nodekey(name)
-            calc_nodes = self._get_calc_node_keys(node_key)
+        calc_nodes: set[NodeKey] = set()
+        names = name if isinstance(name, (types.GeneratorType, list)) else [name]
+        for name0 in names:
+            node_key = to_nodekey(name0)
+            targets = (
+                [node_key]
+                if self.has_node(node_key)
+                else names_to_node_keys(self.get_tree_descendents(node_key, graph_nodes_only=True))
+            )
+            if not targets:
+                targets = [node_key]
+            for target in targets:
+                calc_nodes.update(self._get_calc_node_keys(target))
         self._compute_nodes(calc_nodes, raise_exceptions=raise_exceptions)
 
     def compute_all(self, raise_exceptions: bool = False) -> None:

--- a/tests/test_computeengine.py
+++ b/tests/test_computeengine.py
@@ -1137,6 +1137,76 @@ def test_compute_multiple():
     assert comp.s.d != States.UPTODATE
 
 
+def test_compute_block():
+    """Computing a block runs its nodes but not nodes outside the block."""
+    comp = Computation()
+    comp.add_node("input", value=2)
+    comp.add_node("foo/a", lambda input: input + 1, kwds={"input": "input"})
+    comp.add_node("foo/b", lambda a: a * 2)
+    comp.add_node("outside", lambda input: input - 1)
+
+    comp.compute("foo")
+
+    assert comp.s[["foo/a", "foo/b"]] == [States.UPTODATE, States.UPTODATE]
+    assert comp.v["foo/b"] == 6
+    assert comp.s.outside == States.COMPUTABLE
+
+
+def test_compute_nested_block():
+    """Computing a block includes nodes in nested blocks."""
+    comp = Computation()
+    comp.add_node("foo/a", value=2)
+    comp.add_node("foo/bar/b", lambda a: a + 1, kwds={"a": "foo/a"})
+
+    comp.compute("foo")
+
+    assert comp.s["foo/bar/b"] == States.UPTODATE
+
+
+def test_compute_multiple_blocks():
+    """A list of block names computes each selected block."""
+    comp = Computation()
+    comp.add_node("foo/a", lambda: 1)
+    comp.add_node("bar/a", lambda: 2)
+    comp.add_node("baz/a", lambda: 3)
+
+    comp.compute(["foo", "bar"])
+
+    assert comp.s[["foo/a", "bar/a"]] == [States.UPTODATE, States.UPTODATE]
+    assert comp.s["baz/a"] == States.COMPUTABLE
+
+
+def test_compute_blocks_from_generator():
+    """A generator of block names remains supported."""
+    comp = Computation()
+    comp.add_node("foo/a", lambda: 1)
+    comp.add_node("bar/a", lambda: 2)
+
+    comp.compute(name for name in ["foo", "bar"])
+
+    assert comp.s[["foo/a", "bar/a"]] == [States.UPTODATE, States.UPTODATE]
+
+
+def test_compute_node_takes_precedence_over_block_path():
+    """An exact node target retains the existing single-node behavior."""
+    comp = Computation()
+    comp.add_node("foo", lambda: 1)
+    comp.add_node("foo/a", lambda: 2)
+
+    comp.compute("foo")
+
+    assert comp.s.foo == States.UPTODATE
+    assert comp.s["foo/a"] == States.COMPUTABLE
+
+
+def test_compute_unknown_target_retains_existing_error():
+    """An unknown target continues to raise NetworkXError."""
+    comp = Computation()
+
+    with pytest.raises(nx.NetworkXError):
+        comp.compute("unknown")
+
+
 def test_state_map_with_adding_existing_node():
     """Test state map with adding existing node."""
     comp = Computation()


### PR DESCRIPTION
## Summary

- allow `Computation.compute` to target a block path and compute every node beneath it
- support nested blocks and multiple block targets supplied as a list or generator
- preserve existing node-target behavior and error behavior

## Usage

```python
from loman import Computation

comp = Computation()
comp.add_node("inputs/rate", value=0.05)
comp.add_node("valuation/pv", lambda rate: 100 / (1 + rate), kwds={"rate": "inputs/rate"})
comp.add_node("valuation/risk/dv01", lambda pv: pv * 0.0001, kwds={"pv": "valuation/pv"})

# Compute every node in valuation, including nested blocks.
comp.compute("valuation")

# Multiple blocks are also supported.
comp.compute(["valuation", "inputs"])
```

## Compatibility

This is additive and keeps existing behavior intact:

- exact node names take precedence when a node and block path have the same name
- existing single-node and multi-node calls continue to work
- generators remain supported
- unknown targets retain the existing `networkx.NetworkXError`
- unrelated nodes outside selected blocks are not computed

## Verification

- `make test`: 645 passed, 100% coverage
- `make fmt`: all checks passed
- `uv run ty check src`: passed