### PR TITLE
docs: design plan for a loman[airflow] extra

### DIFF
--- a/docs/development/AIRFLOW_EXTRA_PLAN.md
+++ b/docs/development/AIRFLOW_EXTRA_PLAN.md
@@ -1,0 +1,278 @@
+# Design plan: `loman[airflow]`
+
+Status: proposed, not implemented. This document is the design for review; no code
+has been written on this branch.
+
+## Recommendation
+
+Build `loman.airflow`: a rule-based partitioner that cuts a loman `Computation`
+into a small number of coarse stages, plus a thin emitter that renders those
+stages as Airflow 3 tasks and task groups.
+
+The decision that makes this tractable is that **a loman node is not an Airflow
+task**. The unit of Airflow scheduling is a *stage*: a rule-selected set of nodes
+that runs in one worker process using loman's normal in-process engine. Values
+inside a stage never leave the process. Only values on edges that *cross* a stage
+boundary go through a pluggable value channel.
+
+The mental model to give users: **the Airflow DAG is the collapsed view of the
+loman graph** — the same thing `comp.draw(collapse_all=True)` already renders.
+That framing keeps the serialization problem to a handful of deliberately chosen
+boundary values rather than every intermediate DataFrame, and it lets most of the
+new code be pure Python that never imports Airflow.
+
+## Concept mapping
+
+| loman | Airflow 3 | Notes |
+| --- | --- | --- |
+| `Computation` via a zero-arg factory | `DAG` | Factory, not instance — see below |
+| stage (rule-selected node set) | one `@task` | The scheduling unit; a new concept |
+| loman node | nothing — a node inside a stage | Node-per-task is opt-in via `per="node"` |
+| block, a `NodeKey` path prefix | `TaskGroup` when a block splits into several stages | `a/b/c` becomes `a.b.c` |
+| edge crossing a stage boundary | task dependency plus one channel handle | The only values serialized |
+| edge within a stage | nothing | Stays a Python object in memory |
+| node-held constants (`C`/`ConstantValue`) | baked into the stage at build time | Never need a channel |
+| `NodeAttributes.EXECUTOR` and `executor_map` | `queue` and `pool`, via an explicit rule | Not automatic: `executor_map` holds live `Executor` objects |
+| `default_executor` | intra-task parallelism only | Preserved inside a task |
+| tags | stage-selection predicate | A grammar selector, not an Airflow concept |
+| `validate()` / `ValidationReport` | build-time gate | Refuse to emit a DAG with cycles or placeholders |
+| `States` | does not map | Airflow task states are per-run; loman states are per-graph |
+| partial recalculation | does not map | The deepest mismatch — see risks |
+
+## Proposed API
+
+Two layers. The lower one needs no Airflow at all.
+
+```python
+from datetime import timedelta
+
+from loman.airflow import AirflowSpec, PathChannel, Queue, Stage, StageDefaults, build_plan
+
+SPEC = AirflowSpec(
+    stages=(
+        Stage("market_data/**"),
+        Stage("risk/*", per="block"),
+        Stage.tagged("slow", per="node"),
+        Stage("report"),
+    ),
+    queues=(Queue(executor="gpu", queue="gpu-queue", pool="gpu_pool"),),
+    channel=PathChannel("/mnt/shared/loman/{dag_id}/{run_id}"),
+    defaults=StageDefaults(retries=2, execution_timeout=timedelta(minutes=30)),
+    on_unassigned="single_stage",
+)
+
+plan = build_plan(build_risk_computation(), SPEC)
+plan.to_df()
+```
+
+Selectors reuse the glob language loman already has in `src/loman/nodekey.py`
+(`match_pattern`, `is_pattern`), where `*` matches one path part and `**` matches
+zero or more. The grammar is therefore not a new vocabulary. Every type is a
+frozen dataclass with a `to_df()`, matching `ValidationReport` and
+`ExecutionPlan` in `src/loman/planning.py`.
+
+Only one module imports Airflow:
+
+```python
+from loman.airflow import to_dag
+
+from my_pkg.pipelines import build_risk_computation
+
+dag = to_dag(build_risk_computation, spec=SPEC, dag_id="risk", schedule="@daily")
+```
+
+Inside a worker, each task calls one entry point, which rebuilds the computation
+from the factory, reads inbound handles from the channel and inserts them, calls
+`comp.compute(targets)`, writes outbound boundary values, and returns the small
+handle dict as its XCom.
+
+## Design decisions
+
+### Granularity
+
+Task-per-node gives maximum Airflow UI fidelity but requires serializing every
+intermediate; for loman's typical payloads (DataFrames, curve and portfolio
+objects) that is a non-starter. Whole-computation-in-one-task is trivially
+correct but adds no Airflow value.
+
+Recommended: rule-selected stages, defaulting to one task per top-level block,
+with `per="node"` available per rule. **This needs confirmation** — it is the
+choice that most shapes the feature.
+
+### How values cross a boundary
+
+Airflow 3 removed `enable_xcom_pickling`; XCom is JSON-only. So the plan defines
+a `ValueChannel` protocol with two implementations:
+
+- `XComChannel` runs the value through loman's existing `Transformer` stack,
+  which already handles ndarray, DataFrame and Series, with a size guard that
+  raises rather than bloating the metadata database.
+- `PathChannel` writes a document under `{dag_id}/{run_id}/{task_id}/{node}` on
+  shared storage and puts only the URI in XCom.
+
+`PathChannel` is the recommended default for real use. The protocol is public so
+users can back it with object storage. The docs must be honest that loman's
+"arbitrary Python object" guarantee stops at a stage boundary.
+
+### Output form
+
+`to_dag` takes a **zero-arg factory, not a `Computation` instance**. Airflow
+re-parses DAG files roughly every 30 seconds, and the same graph must be rebuilt
+deterministically in the scheduler, the DAG processor and every worker. Building
+a loman graph is construction only, with no compute, so it is cheap — provided
+the factory does not hit a database.
+
+Validate at build time that the factory is importable, reusing
+`FunctionRefTransformer.to_dict()` in `src/loman/serialization/transformer.py`,
+which already does an import round-trip check and rejects lambdas and closures.
+Users then get a clear error at parse time rather than a mystery worker failure.
+
+Source generation is plausible later but v1 should not own a code generator.
+
+### Which loman API is the bridge
+
+`create_execution_plan` in `src/loman/planning.py` prunes anything already
+`UPTODATE` or `PINNED` and reports uninitialized inputs as blocked, so its output
+is state-dependent and wrong as a source of DAG shape: a freshly built graph
+would report every input as blocked.
+
+Instead, at build time call `validate_graph` to reject cycles, placeholders and
+missing executors, compute the partition and the quotient graph over stages from
+`comp.dag` directly, and topologically sort with `graph_utils.topological_sort`.
+A rule set producing a cyclic quotient must be a build-time error naming the
+crossing edges — this is the main correctness obligation of the module.
+
+At run time, inside a task, `comp.compute(targets)` already does the right
+partial recalculation, and `comp.plan(targets).to_df()` is good task-log material.
+
+### Task identifier stability
+
+Airflow validates identifiers against `^[A-Za-z0-9_\-.]+$` with a 250 character
+limit, and task groups prefix with `.`. Two things must be errors rather than
+silent mangling: node keys with non-string parts, whose `str()` is not a stable
+identity; and two distinct keys sanitizing to the same identifier. Identifiers
+must be stable across parses or Airflow loses task history.
+
+### Dependency choice
+
+Recommended: depend on `apache-airflow-task-sdk` rather than full
+`apache-airflow`. The Task SDK is a separate distribution intended for DAG
+authoring without installing Airflow core, and exports everything needed. This
+makes the extra small enough to install in CI.
+
+Unverified and worth a short spike: whether the Python TaskFlow `@task`
+decorator resolves with the SDK alone or also needs
+`apache-airflow-providers-standard`, since `PythonOperator` lives in that
+provider.
+
+## Layout and packaging
+
+```text
+src/loman/airflow/__init__.py     exports; lazy to_dag via module __getattr__
+src/loman/airflow/spec.py         AirflowSpec, Stage, Group, Queue, StageDefaults
+src/loman/airflow/partition.py    selector matching, stage assignment, quotient graph
+src/loman/airflow/plan.py         DagPlan, StagePlan, Crossing, to_df()
+src/loman/airflow/naming.py       NodeKey to task_id, legality and collision checks
+src/loman/airflow/channels.py     ValueChannel protocol, XComChannel, PathChannel
+src/loman/airflow/runtime.py      execute_stage()
+src/loman/airflow/_sdk.py         the only module that imports airflow
+src/loman/airflow/dag.py          to_dag()
+```
+
+`dag.py` must reference the SDK as attributes (`_sdk.task(...)`) rather than
+importing the names directly, so tests can monkeypatch `loman.airflow._sdk`
+without touching `sys.modules`. This works whether or not Airflow is installed,
+which is the whole coverage strategy.
+
+Nothing outside `src/loman/airflow/` imports it, and `src/loman/__init__.py` is
+untouched. No `Computation.to_airflow()` method in v1.
+
+The `[project.optional-dependencies]` convention and the shared optional-import
+helper are **owned by the `loman[ui]` branch**; this branch adds only its own
+entry once that has landed:
+
+```toml
+[project.optional-dependencies]
+airflow = ["apache-airflow-task-sdk>=1.0,<2"]
+
+[tool.deptry.package_module_name_map]
+apache-airflow-task-sdk = "airflow"
+```
+
+The deptry entry is required because the distribution and module names differ.
+
+## Delivery phases
+
+| Phase | Content | Ships alone |
+| --- | --- | --- |
+| 0 | Spike: does the Task SDK alone give a working `@task`? Does it install on Windows and Python 3.14? | n/a |
+| 1 | `spec.py`, `partition.py`, `naming.py`, `plan.py`. Pure Python, no new dependency | yes |
+| 2 | `channels.py`, `runtime.py`. Round-trips a multi-stage computation with no Airflow present | yes |
+| 3 | `_sdk.py`, `dag.py`, `to_dag()`, pyproject entry, CI job | yes |
+| 4 | Docs page, mkdocs nav entry, changelog, install note | yes |
+| 5 | Later: dynamic task mapping, asset-based scheduling, channel short-circuit as a partial-recalc analogue | — |
+
+Phases 1 and 2 are valuable even if phase 3 never merges, which makes this low
+risk to start.
+
+## Testing approach
+
+`make test` runs coverage in every matrix job, so each of ubuntu, macos and
+windows across Python 3.11 to 3.14 must independently hit the bar. Airflow does
+not install on Windows and its Python 3.14 support is unconfirmed, so **coverage
+cannot depend on Airflow being present**. Three tiers:
+
+1. Pure tests for the partitioner, naming, plan and channels — ordinary Python
+   over a `networkx` graph, testable the way `tests/test_planning.py` already is,
+   reusing the fixtures in `tests/conftest.py`.
+2. Stubbed emitter tests: a fake SDK recorder monkeypatched onto
+   `loman.airflow._sdk`, asserting the emitted structure matches the plan. This
+   gives real line coverage of `dag.py` on every platform. Only the small
+   try/except in `_sdk.py` carries a coverage pragma.
+3. One real integration test on ubuntu with a single Python version, guarded by
+   `pytest.importorskip`, asserting against Airflow's own API. This is the guard
+   against the fake drifting from reality.
+
+Note that `ty` runs on `src/` without Airflow installed, so the import in
+`_sdk.py` will be unresolved. Expect to need a suppression or a `TYPE_CHECKING`
+shim; check this early in phase 3.
+
+## Risks and open questions
+
+Fundamental mismatches, which should be stated plainly in the docs:
+
+- Partial recalculation has no Airflow equivalent. loman recomputes only what is
+  stale from live in-memory state; Airflow reruns a DAG on a schedule. The
+  nearest analogue is short-circuiting when a channel handle already exists,
+  which is a weaker guarantee and a later feature.
+- loman states and Airflow task states are different things and should never be
+  conflated.
+- XCom is JSON-only in Airflow 3, so arbitrary objects crossing a boundary need
+  `PathChannel` or a custom backend.
+
+Needing a decision:
+
+- Default granularity: one task per top-level block, per-node, or no default at
+  all.
+- Whether v1 adds a convenience method on `Computation` or keeps everything in
+  `loman.airflow`.
+- `apache-airflow-task-sdk` versus full `apache-airflow`.
+- Which channel is the default.
+
+To verify before phase 3:
+
+- Whether `@task` needs `apache-airflow-providers-standard`.
+- Whether the Task SDK installs on Windows and Python 3.14.
+- Whether Airflow 3 has a per-task `executor` parameter, or whether queue-based
+  routing is the only per-task lever.
+- The exact SDK version floor.
+
+Operational risks:
+
+- A factory that touches a database at parse time will be re-executed every 30
+  seconds by the DAG processor. This is the most likely way a user gets hurt and
+  needs a loud documentation warning.
+- Any change to the grammar or to block names silently renames tasks and orphans
+  their Airflow history. Consider emitting a stable identifier manifest that can
+  be diffed in review.
+- Adding the extra will produce a large `uv.lock` diff; worth a separate commit.


### PR DESCRIPTION
Design plan only — no implementation. Opening as a draft so the architecture can be argued before any code exists.

Full plan: [`docs/development/AIRFLOW_EXTRA_PLAN.md`](docs/development/AIRFLOW_EXTRA_PLAN.md)

## What is proposed

`loman.airflow`: a rule-based partitioner that cuts a `Computation` into coarse stages, plus a thin emitter rendering them as Airflow 3 tasks and task groups.

```python
SPEC = AirflowSpec(
    stages=(Stage("market_data/**"), Stage("risk/*", per="block")),
    channel=PathChannel("/mnt/shared/loman/{dag_id}/{run_id}"),
)
plan = build_plan(build_risk_computation(), SPEC)   # DagPlan, with .to_df()
dag = to_dag(build_risk_computation, spec=SPEC, dag_id="risk", schedule="@daily")
```

Selectors reuse loman's existing `NodeKey` glob language (`*`, `**`), so the grammar is not a new vocabulary.

## The decision that needs arguing

**A loman node is not an Airflow task.** The scheduling unit is a *stage*: a rule-selected set of nodes that runs in one worker on loman's own in-process engine. Values inside a stage never leave the process; only values on edges that *cross* a boundary are serialized.

The mental model: **the Airflow DAG is the collapsed view of the loman graph** — the picture `comp.draw(collapse_all=True)` already produces.

Node-per-task would turn a 200-node graph into 200 tasks with 200 serialization round-trips of DataFrames. Since Airflow 3 removed XCom pickling and XCom is now JSON-only, that is not a viable default. Node-per-task stays available per rule via `per="node"`.

## Two findings that shaped it

`ExecutionPlan` looks like the obvious bridge and is the wrong one. It prunes anything already `UPTODATE` and reports uninitialized inputs as blocked, so its output is state-dependent — a freshly built graph would report every input blocked. The right build-time source of DAG shape is `validate()` plus a quotient graph over stages, topologically sorted; a rule set producing a cyclic quotient must be a build-time error naming the crossing edges.

`to_dag` takes a **zero-arg factory, not a `Computation`**, because Airflow re-parses DAG files roughly every 30 seconds and the graph must rebuild identically in scheduler, DAG processor and every worker. The plan reuses `FunctionRefTransformer` to reject non-importable factories at parse time rather than failing mysteriously in a worker.

## Why the phasing is low-risk

Phases 1 and 2 — the partitioner, naming, plan dataclass, channels and runtime — are **pure Python with no new dependency at all**. `build_plan(comp, spec).to_df()` answers "how would this graph be cut up?" and is shippable before any Airflow code exists.

## The CI constraint

Airflow does not install on Windows, and the coverage gate runs on every matrix job across Python 3.11–3.14 on three platforms. So coverage cannot depend on Airflow being present. The plan isolates every Airflow import into one small module, referenced by attribute so it can be monkeypatched, and covers the emitter with a fake-SDK recorder on all platforms plus one real integration job to catch drift.

## Honest mismatches, to be stated in the docs

- **Partial recalculation has no Airflow equivalent.** loman recomputes what is stale from live in-memory state; Airflow reruns on a schedule.
- loman states and Airflow task states are different things and should not be conflated.
- Arbitrary Python objects crossing a stage boundary need a path/object-store channel, not XCom.

## Open questions for review

- Default granularity: one task per top-level block (recommended), per-node, or no default?
- `apache-airflow-task-sdk` (light, recommended) or full `apache-airflow`?
- Which channel is the default — XCom (zero infra, small values) or path-backed (needs shared storage, actually usable)?
- Does the TaskFlow `@task` decorator resolve with the Task SDK alone, or does it also need `apache-airflow-providers-standard`? Needs a spike.

## Dependency note

The shared extras convention is owned by the sibling `loman[ui]` plan (#335), which specifies the pyproject stanzas, the deptry map entries and the shared `src/loman/_extras.py` helper. This branch adds only its own entry against that convention. Two constraints established there land squarely on this extra:

- **The declaration cannot precede the importing code.** `deptry` runs over `src/` in CI and rejects an extra nothing imports (DEP002), so the `airflow = [...]` stanza ships with the first module that imports the SDK, not before.
- **`make install` runs `uv sync --all-extras --all-groups`**, so every extra is expected to install on every matrix platform. Airflow has no Windows support, so it needs a `; sys_platform != "win32"` marker or a dedicated dependency group the matrix does not sync. Worth settling in phase 0 rather than after a red Windows job.

