### PR TITLE
docs: correct README license badge to BSD-3-Clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Manage complex calculation flow via robust DAG-based dependency logic in Python
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-green.svg)](LICENSE)
 [![Python versions](https://img.shields.io/badge/Python-3.11%20•%203.12%20•%203.13%20•%203.14-blue?logo=python)](https://www.python.org/)
 [![PyPI - Version](https://img.shields.io/pypi/v/loman.svg)](https://pypi.python.org/pypi/loman)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/loman.svg)](https://pypi.python.org/pypi/loman)


### PR DESCRIPTION
## Summary

The license badge at the top of `README.md` advertises **MIT**. The project is **BSD 3-Clause**, per both `LICENSE` and the manifest. This corrects the badge.

```diff
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-green.svg)](LICENSE)
```

The badge URL uses shields.io escaping — `_` for the space, `--` for the literal hyphen — so it renders as **License: BSD 3-Clause**. The link target is unchanged.

## Why

Three places state the license, and one of them disagreed with the other two:

| Source | Says |
| --- | --- |
| `README.md:8` | MIT ❌ |
| `LICENSE:1` | `BSD 3-Clause License` |
| `pyproject.toml:21` | `license = "BSD-3-Clause"` |

The README is the most-read file in the repo and the first thing a prospective user checks, so it was the wrong one to be wrong.

## Testing

`make fmt` passes — 17 hooks green, including `markdownlint` and the README/Makefile-help sync hook. One line changed; nothing else in the working tree moved.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
