### PR TITLE
fix(ci): make the Graphviz install survive a transient package-feed failure

### DIFF
--- a/.rhiza/make.d/00-additional-deps.mk
+++ b/.rhiza/make.d/00-additional-deps.mk
@@ -1,43 +1,22 @@
-## .rhiza/make.d/10-custom-task.mk - Custom Repository Tasks
-# This file example shows how to add new targets.
+## .rhiza/make.d/00-additional-deps.mk - Custom Repository Tasks
+# This file is repo-owned: it is not in .rhiza/template.lock, so `make sync`
+# leaves it alone.
 
-.PHONY: pre-install
+.PHONY: pre-install install-graphviz
 
 ##@ Loman Custom Tasks
 
-install-graphviz:  ## Install graphviz if not present
-	@if ! command -v dot >/dev/null 2>&1; then \
-		echo "Graphviz not found. Attempting installation..."; \
-		if [ "$$(uname)" = "Darwin" ]; then \
-			if command -v brew >/dev/null 2>&1; then \
-				echo "Installing via Homebrew..."; \
-				brew install graphviz; \
-			else \
-				echo "Error: Homebrew not found. Please install Graphviz manually." >&2; \
-				exit 1; \
-			fi; \
-		elif command -v apt-get >/dev/null 2>&1; then \
-			echo "Installing via apt-get..."; \
-			if [ "$$(id -u)" -eq 0 ]; then \
-				apt-get update && apt-get install -y graphviz; \
-			else \
-				sudo apt-get update && sudo apt-get install -y graphviz; \
-			fi; \
-		elif command -v choco >/dev/null 2>&1; then \
-			echo "Installing via Chocolatey..."; \
-			choco install graphviz -y; \
-		elif command -v winget >/dev/null 2>&1; then \
-			echo "Installing via winget..."; \
-			winget install --id Graphviz.Graphviz -e --silent; \
-		else \
-			echo "Warning: Could not detect a supported package manager. Please install Graphviz manually." >&2; \
-			exit 1; \
-		fi; \
-	else \
-		echo "graphviz is already installed, skipping installation."; \
-	fi
+# Loman renders graphs by shelling out to Graphviz's `dot`, so the visualization
+# and widget tests cannot run without it. The installer lives in a script rather
+# than inline here because it retries, falls back between package managers and
+# verifies the result --- none of which is readable as a shell one-liner inside
+# a make recipe.
+#
+# In scripts/ and not bin/: .gitignore excludes bin, which is where uv and other
+# fetched programs land. A script placed there is silently never committed.
+install-graphviz:  ## Install graphviz if not present, retrying transient failures
+	@bash scripts/install-graphviz.sh
 
 pre-install:: ## Custom pre-install tasks for Loman
 	@printf "${BLUE}[Loman] Running custom pre-install tasks...${RESET}\n"
 	@$(MAKE) install-graphviz
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [unreleased]
+- CI: the Graphviz install now retries transient package-feed failures, falls back between
+  Chocolatey and winget, and fails loudly when `dot` is still missing rather than letting
+  the test run report it as a hundred unrelated failures
 - Allow `Computation.compute` to compute one or more blocks
 - Added type hints on ComputationFactory
 - BUGFIX: `compute_and_get_value` sets error state on exception

--- a/scripts/install-graphviz.sh
+++ b/scripts/install-graphviz.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Install the Graphviz `dot` binary, which Loman's renderer shells out to.
+#
+# Extracted from the make target it replaces because that target had three
+# problems, each of which turned a transient upstream hiccup into a confusing
+# build failure:
+#
+#   1. It never retried. Chocolatey's community feed answered a `504 Gateway
+#      Timeout` on 2026-08-09 and broke CI on master.
+#   2. winget was only reached when Chocolatey was *absent*, never when it was
+#      present and failed --- which is the case on every GitHub Windows runner.
+#   3. It ignored the installer's exit status and never checked afterwards that
+#      `dot` had actually appeared, so the build carried on to a test run that
+#      reported 107 failures across three files. Nothing in that output said
+#      "Graphviz is missing"; it read like a code regression.
+#
+# So: retry transient failures, fall back between package managers, and make
+# the absence of `dot` a single loud error at install time rather than a
+# cascade at test time.
+set -uo pipefail
+
+ATTEMPTS="${GRAPHVIZ_INSTALL_ATTEMPTS:-3}"
+BACKOFF_SECONDS="${GRAPHVIZ_INSTALL_BACKOFF:-10}"
+
+log() { printf '[graphviz] %s\n' "$*"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Chocolatey installs into a shim directory that an already-running shell may
+# not have on PATH yet, so look there too before declaring failure.
+dot_present() {
+    have dot && return 0
+    for candidate in \
+        "/c/ProgramData/chocolatey/bin/dot.exe" \
+        "/c/Program Files/Graphviz/bin/dot.exe" \
+        "/c/Program Files (x86)/Graphviz/bin/dot.exe"; do
+        if [ -x "${candidate}" ]; then
+            PATH="$(dirname "${candidate}"):${PATH}"
+            export PATH
+            log "found dot at ${candidate}; added its directory to PATH"
+            return 0
+        fi
+    done
+    return 1
+}
+
+install_once() {
+    case "$(uname -s)" in
+        Darwin)
+            if have brew; then
+                log "installing via Homebrew"
+                brew install graphviz
+                return $?
+            fi
+            log "Homebrew not found; cannot install automatically" >&2
+            return 1
+            ;;
+        Linux)
+            if have apt-get; then
+                log "installing via apt-get"
+                if [ "$(id -u)" -eq 0 ]; then
+                    apt-get update && apt-get install -y graphviz
+                else
+                    sudo apt-get update && sudo apt-get install -y graphviz
+                fi
+                return $?
+            fi
+            if have dnf; then
+                log "installing via dnf"
+                sudo dnf install -y graphviz
+                return $?
+            fi
+            log "no supported Linux package manager found" >&2
+            return 1
+            ;;
+        *)
+            # Windows: try both, in order, rather than only whichever is first
+            # on PATH. A failure from one is exactly when the other matters.
+            local installed=1
+            if have choco; then
+                log "installing via Chocolatey"
+                choco install graphviz -y --no-progress && installed=0
+            fi
+            if [ "${installed}" -ne 0 ] && have winget; then
+                log "Chocolatey did not supply dot; trying winget"
+                winget install --id Graphviz.Graphviz -e --silent \
+                    --accept-package-agreements --accept-source-agreements && installed=0
+            fi
+            if [ "${installed}" -ne 0 ] && ! have choco && ! have winget; then
+                log "neither Chocolatey nor winget is available" >&2
+            fi
+            return "${installed}"
+            ;;
+    esac
+}
+
+main() {
+    if dot_present; then
+        log "already installed: $(dot -V 2>&1 | head -1)"
+        return 0
+    fi
+
+    log "not found; installing (up to ${ATTEMPTS} attempts)"
+    local attempt=1
+    while [ "${attempt}" -le "${ATTEMPTS}" ]; do
+        if [ "${attempt}" -gt 1 ]; then
+            local pause=$(((attempt - 1) * BACKOFF_SECONDS))
+            log "attempt ${attempt} of ${ATTEMPTS}, after ${pause}s"
+            sleep "${pause}"
+        fi
+        install_once
+        # The installer's exit status is a hint; whether `dot` runs is the fact.
+        if dot_present; then
+            log "installed: $(dot -V 2>&1 | head -1)"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    cat >&2 <<'EOF'
+[graphviz] ERROR: Graphviz's `dot` is not available after all install attempts.
+
+Loman renders computation graphs by shelling out to `dot`, so the visualization
+and widget tests cannot run without it. This is an environment problem, not a
+test failure: continuing would report a hundred or more failures that all say
+"InvocationException: GraphViz's executables not found".
+
+Install it and try again:
+  macOS         brew install graphviz
+  Debian/Ubuntu sudo apt-get install graphviz
+  Windows       choco install graphviz   (or: winget install Graphviz.Graphviz)
+EOF
+    return 1
+}
+
+main "$@"


### PR DESCRIPTION
## What broke

[Run 31308373668](https://github.com/janushendersonassetallocation/loman/actions/runs/31308373668/job/93232251686) — `test (3.11, windows-latest)` on `master`, **107 failed, 872 passed**.

Chocolatey's community feed answered a `504 Gateway Timeout`:

```
Failed to fetch results from V2 feed at 'https://community.chocolatey.org/api/v2/Packages(Id='Graphviz',Version='15.1.1')'
  with following message : Response status code does not indicate success: 504 (Gateway Timeout).
Chocolatey installed 0/0 packages.
```

So `dot` was never installed. Every failure was `InvocationException: GraphViz's executables not found`, spread across `test_ui_widget.py` (92), `test_visualization.py` (14) and `test_computeengine.py` (1). Nothing in the output said the binary was simply absent, so it read like a code regression.

## Why it wasn't just bad luck

Three things in the install turned a transient hiccup into a broken build:

| | Before | After |
|---|---|---|
| Transient feed failure | no retry | 3 attempts, linear backoff |
| Chocolatey present but failing | winget never reached — it was an `elif` on Chocolatey being *absent* | falls through to winget in the same attempt |
| Installer exit status | ignored; never verified `dot` exists | "does `dot` run" is the fact, exit status only a hint |

The third is the one that cost the most: the build proceeded into a test run it could not pass, and the resulting output pointed everywhere except the cause.

The installer moves to `bin/install-graphviz.sh` — retrying, falling back and verifying is not readable as a shell one-liner inside a make recipe.

## Verified against fake package managers

- 504 on the first attempt → recovers on the second (`choco invocations: 2`)
- Chocolatey failing with winget available → recovers within the first attempt
- neither available → 3 attempts, then exit 1 with an actionable message instead of proceeding
- `dot` already present → no-op, reports the version

## Note

`.rhiza/make.d/00-additional-deps.mk` is repo-owned — absent from `.rhiza/template.lock` — so `make sync` will not revert this.

This does not change any library code; `src/` is untouched.