### PR TITLE
docs: design plan for typed and abstract computations

### DIFF
--- a/docs/development/TYPED_COMPUTATIONS_PLAN.md
+++ b/docs/development/TYPED_COMPUTATIONS_PLAN.md
@@ -5,9 +5,34 @@ has been written on this branch.
 
 ## Recommendation
 
-Add `loman.ComputationBase`, a `Computation` subclass that populates itself from
-its own class body, so a computation is **declared by inheritance rather than by
-decoration**:
+Two independent things are being asked for, and separating them is the main
+decision in this document.
+
+**The interface — "this computation is a Signal" — should be defined over
+`Computation`, not over how the computation was built.** A contract is a
+statement about a graph: these nodes exist, this one is an input, that one is a
+calculation. Nothing about that depends on whether the graph came from a
+decorator, from inheritance, or from `add_node` calls in a loop. Defining it that
+way means the existing `@ComputationFactory` gets interfaces on day one, with no
+migration:
+
+```python
+class Signal(ComputationInterface):
+    prices = required_input()
+    df_signals = required_calc()
+
+Signal.check(comp)      # -> report, over any Computation
+sig = Signal.view(comp) # -> typed facade; sig.df_signals is statically typed
+```
+
+This was prototyped against real loman and the same contract accepted
+decorator-built, inheritance-built and imperatively-built computations
+identically, rejecting a non-conforming one with reasons
+(`"missing node 'df_signals'"`, `"'prices' should be an input"`).
+
+**Separately**, `loman.ComputationBase` lets a computation be declared by
+inheriting rather than decorating, which is the only way to give the computation
+*object itself* a usable static type:
 
 ```python
 class Signal(ComputationBase):
@@ -18,12 +43,12 @@ class Signal(ComputationBase):
         return prices * 2
 ```
 
-`@ComputationFactory` keeps working unchanged; this is additive.
+`@ComputationFactory` keeps working unchanged; both are additive.
 
-The reason is narrow and measurable. A class decorator that returns something
-other than the class **cannot be typed**, in any current checker, by design. The
-consequence today is that every legitimate use of a factory-built computation is
-a false positive:
+The reason the second one is needed at all is narrow and measurable. A class
+decorator that returns something other than the class **cannot be typed**, in any
+current checker, by design. The consequence today is that every legitimate use of
+a factory-built computation is a false positive:
 
 ```text
 error[unresolved-attribute]: Object of type `Signal` has no attribute `compute_all`
@@ -34,12 +59,14 @@ error[unresolved-attribute]: Object of type `Signal` has no attribute `v`
 Inheritance produces none of those, while still catching real mistakes, because
 the declared class genuinely *is* the type of the object you get back.
 
-As a second-order effect it also gives abstract computations essentially for
-free, which is the other thing being asked for.
+The order matters for delivery: the interface layer is worth more, is not
+blocked on anything, and helps every existing user. `ComputationBase` is worth
+having, but only decorator users who also want the computation object typed have
+to adopt it.
 
 ## Evidence
 
-Five shapes were measured under `ty`, each with a deliberate nonsense call to
+Six shapes were measured under `ty`, each with a deliberate nonsense call to
 confirm the checker was really looking.
 
 | shape | inferred type | legitimate calls | nonsense caught |
@@ -47,10 +74,11 @@ confirm the checker was really looking.
 | class decorator returning a factory function (today) | the class | **all error** | yes, for the wrong reason |
 | the same decorator applied by assignment | `Computation` | pass | yes |
 | class decorator returning `type[Computation]` | the class | error | — |
+| a class declaring `__new__` returning `Computation` | the class | error | — |
 | **inheritance** | the subclass | pass | yes |
-| typed facade over a computation | the facade | pass | yes, and node values are typed |
+| **typed facade over a computation** | the facade | pass | yes, and node values are typed |
 
-Two findings matter more than the table.
+Three findings matter more than the table.
 
 **Class-decorator return types are ignored regardless of what they are.** The
 third row is the control: annotating the decorator as returning
@@ -58,6 +86,17 @@ third row is the control: annotating the decorator as returning
 so no annotation, overload or stub can fix the current shape. An earlier
 suggestion to add `@overload` to `computation_factory` was tested and does not
 work.
+
+**Nor does `__new__`.** The fourth row is the last mechanism that could have
+rescued the decorator form: a class whose `__new__` is declared to return
+`Computation`. `ty` ignores that too. There is no way to make the decorated
+symbol itself type as a computation, so anything that needs the decorator to keep
+working must go through the facade rather than through the decorated name.
+
+**The facade works over anything.** It is an ordinary class, so its attributes
+type normally, and it takes a `Computation` rather than caring where the
+computation came from. That is what lets the interface layer serve decorator
+users without asking them to change how they build computations.
 
 **The assignment form does type correctly.** `Signal = computation_factory(Spec)`
 infers `Computation`, because it is an ordinary call rather than a class
@@ -113,7 +152,59 @@ What inheritance does **not** cover, and still needs machinery:
 
 ## Proposed API
 
-### Layer 1: `ComputationBase`
+The first two layers work over any `Computation`, whatever built it. Only the
+third asks a user to change how they declare one.
+
+### Layer 1: structural contracts
+
+```python
+class Signal(ComputationInterface):
+    prices = required_input()
+    df_signals = required_calc()
+
+Signal.check(comp)      # -> report, in the idiom of validate() and to_df()
+```
+
+Two independent kinds of assertion — node presence and kind, and dependency shape
+— usable separately or together, because an interface that pins wiring is
+sometimes what you want and usually is not:
+
+```python
+class Signal(ComputationInterface):
+    df_signals = required_calc(depends_on=["prices"])   # opt-in, not the default
+```
+
+The prototype's report is a list of reasons rather than a bare boolean, which is
+what makes it useful at a boundary: `"missing node 'df_signals'"`,
+`"'prices' should be an input"`.
+
+### Layer 2: typed node access
+
+```python
+sig = Signal.view(comp)     # facade; sig.df_signals is statically a DataFrame
+```
+
+Only the facade can type node values, since attribute access on a real class is
+checkable where string-keyed access is not. `view` checks conformance first and
+refuses a computation that does not satisfy the contract, so a typed handle
+cannot be obtained for a graph that would not support it.
+
+Together these two layers give a decorator user everything except a static type
+for the computation object:
+
+```python
+@ComputationFactory
+class MySignal:
+    prices = input_node()
+
+    @calc_node
+    def df_signals(self, prices): ...
+
+
+sig = Signal.view(MySignal())   # typed, conformance-checked, no migration
+```
+
+### Layer 3: `ComputationBase`
 
 ```python
 class ComputationBase(Computation):
@@ -127,28 +218,25 @@ class ComputationBase(Computation):
 `_ignore_self` stays a class attribute so the per-class opt-out that
 `@ComputationFactory(ignore_self=False)` provides has an equivalent.
 
-### Layer 2: structural contracts
+This is the layer that types the computation object itself, and the one that
+requires adopting a new declaration style. Worth having, and worth being last.
 
-For computations not built by inheritance:
+### Declaring conformance at construction
 
-```python
-Signal.check(comp)          # -> report, in the idiom of validate() and to_df()
-Signal.requires(depends_on={"df_signals": ["prices"]})   # dependency shape, opt-in
-```
-
-Two independent checks — node presence and kind, and dependency shape — usable
-separately or together, because an interface that pins wiring is sometimes what
-you want and usually is not.
-
-### Layer 3: typed node access
+A factory can name the interfaces it claims, so a broken implementation fails
+where it is defined rather than at the call site that needed it:
 
 ```python
-sig = Signal.view(comp)     # facade; sig.df_signals is statically a DataFrame
+@ComputationFactory(implements=Signal)
+class MySignal: ...
+
+
+class MySignal(ComputationBase, implements=Signal): ...
 ```
 
-Only the facade can type node values, since attribute access on a real class is
-checkable where string-keyed access is not. Worth designing now, but shippable
-last.
+Both are runtime checks — the static type of the decorator form is unaffected,
+for the reasons in the evidence section. The value is that the error arrives at
+construction with the contract's reasons attached.
 
 ## What this makes redundant downstream
 
@@ -171,28 +259,38 @@ decorator is kept as-is, the annotations should be set rather than inherited.
   be, since silently downgrading the type is worse than not having it.
 - **Deserialization loses the subclass.** Unavoidable: the deserializer has no
   way to know which class produced the graph. Must be documented, and it argues
-  for the structural `check()` in layer 2 as the way to re-establish an interface
-  after a roundtrip.
+  for the structural `check()` in layer 1 as the way to re-establish an interface
+  after a roundtrip — which works precisely because the contract is defined over
+  `Computation` rather than over the class that built it.
 - **Two ways to define a computation.** The decorator and the base class would
   coexist indefinitely. That is a genuine cost in documentation and in answering
-  "which should I use". The docs should recommend one — the base class — and
-  explain that the decorator remains supported.
+  "which should I use". Splitting the interface layer out of the base class
+  softens it considerably: the answer becomes "either, and interfaces work with
+  both", rather than "switch". The docs should still say which is recommended for
+  new code.
 
 ## Delivery phases
 
 Each phase leaves the branch green and is independently reviewable.
 
-- **Phase 1 — `ComputationBase`.** The class, tests covering equivalence with the
+- **Phase 1 — structural contracts.** `ComputationInterface` and `check()`,
+  returning a report in the existing `ValidationReport` idiom, with node presence
+  and kind. Dependency shape as an opt-in second assertion. Works over any
+  `Computation`, so it lands value for existing `@ComputationFactory` users
+  without asking them to change anything, and it does not depend on any of the
+  phases below.
+- **Phase 2 — the typed facade.** `view()`, checking conformance before handing
+  back a typed handle. This is what gives decorator users typed node access.
+- **Phase 3 — `ComputationBase`.** The class, tests covering equivalence with the
   decorator, `self`-binding, and subclass composition. Docs page and a changelog
   entry. No change to existing behaviour.
-- **Phase 2 — `copy()` preserves the subclass**, plus a test. Small and separable.
-- **Phase 3 — structural contracts.** `check()` returning a report in the
-  existing `ValidationReport` idiom, with node presence and kind. Dependency
-  shape as an opt-in second check.
-- **Phase 4 — typed node access.** The facade, and whatever generation or
-  declaration it needs to stay in step with the interface.
-- **Phase 5 — documentation.** Recommend the base class, document the decorator
-  as supported, and state the copy and serialization caveats plainly.
+- **Phase 4 — `copy()` preserves the subclass**, plus a test. Small and separable,
+  and only meaningful once phase 3 exists.
+- **Phase 5 — conformance at construction.** `implements=` on both the decorator
+  and the base class, as a runtime check reporting the contract's reasons.
+- **Phase 6 — documentation.** Show interfaces working with both declaration
+  styles, say which is recommended for new code, and state the copy and
+  serialization caveats plainly.
 
 ## Testing approach
 

--- a/docs/development/TYPED_COMPUTATIONS_PLAN.md
+++ b/docs/development/TYPED_COMPUTATIONS_PLAN.md
@@ -1,0 +1,226 @@
+# Design plan: typed and abstract computations
+
+Status: proposed, not implemented. This document is the design for review; no code
+has been written on this branch.
+
+## Recommendation
+
+Add `loman.ComputationBase`, a `Computation` subclass that populates itself from
+its own class body, so a computation is **declared by inheritance rather than by
+decoration**:
+
+```python
+class Signal(ComputationBase):
+    prices = input_node()
+
+    @calc_node
+    def df_signals(self, prices):
+        return prices * 2
+```
+
+`@ComputationFactory` keeps working unchanged; this is additive.
+
+The reason is narrow and measurable. A class decorator that returns something
+other than the class **cannot be typed**, in any current checker, by design. The
+consequence today is that every legitimate use of a factory-built computation is
+a false positive:
+
+```text
+error[unresolved-attribute]: Object of type `Signal` has no attribute `compute_all`
+error[unresolved-attribute]: Object of type `Signal` has no attribute `insert`
+error[unresolved-attribute]: Object of type `Signal` has no attribute `v`
+```
+
+Inheritance produces none of those, while still catching real mistakes, because
+the declared class genuinely *is* the type of the object you get back.
+
+As a second-order effect it also gives abstract computations essentially for
+free, which is the other thing being asked for.
+
+## Evidence
+
+Five shapes were measured under `ty`, each with a deliberate nonsense call to
+confirm the checker was really looking.
+
+| shape | inferred type | legitimate calls | nonsense caught |
+| --- | --- | --- | --- |
+| class decorator returning a factory function (today) | the class | **all error** | yes, for the wrong reason |
+| the same decorator applied by assignment | `Computation` | pass | yes |
+| class decorator returning `type[Computation]` | the class | error | — |
+| **inheritance** | the subclass | pass | yes |
+| typed facade over a computation | the facade | pass | yes, and node values are typed |
+
+Two findings matter more than the table.
+
+**Class-decorator return types are ignored regardless of what they are.** The
+third row is the control: annotating the decorator as returning
+`type[Computation]` changes nothing. This is long-standing, deliberate behaviour,
+so no annotation, overload or stub can fix the current shape. An earlier
+suggestion to add `@overload` to `computation_factory` was tested and does not
+work.
+
+**The assignment form does type correctly.** `Signal = computation_factory(Spec)`
+infers `Computation`, because it is an ordinary call rather than a class
+decorator. It is worth documenting as an immediate workaround for anyone blocked
+today, but it discards the class identity, so it is a stopgap and not the
+destination.
+
+## Prototype results
+
+`ComputationBase` was prototyped against real loman and compared with the
+existing decorator on the same model.
+
+- **Runtime is identical.** Same generated nodes, same computed result.
+- **Typing is correct.** `compute_all`, `insert` and `v` all resolve; a nonsense
+  attribute is still an error.
+- **`isinstance(s, Computation)` is true**, which the decorator cannot offer.
+- **Declared nodes are reachable as class attributes.** `Signal.prices` is an
+  `InputNode`. Consumers currently hand-roll this by walking the class and
+  calling `setattr` on the returned function.
+- **Name and docstring are preserved natively**, with no `functools.wraps`. That
+  also removes an existing bug, described below.
+- **`self`-binding in calc nodes still works**, so helper methods are unaffected.
+
+### Abstract computations fall out of it
+
+This ran as-is in the prototype:
+
+```python
+class AbstractSignal(ComputationBase):
+    prices = input_node()
+
+class ConcreteSignal(AbstractSignal):
+    @calc_node
+    def df_signals(self, prices):
+        return prices * 3
+```
+
+Both nodes are present on the instance, `isinstance(c, AbstractSignal)` is true,
+and `def run(sig: AbstractSignal)` type-checks at the call site. Subclassing *is*
+the declaration, and it is enforced at construction because construction is what
+populates the graph.
+
+What inheritance does **not** cover, and still needs machinery:
+
+- **Structural checking of a computation built some other way** — imperatively,
+  or by repeated blocks. An interface should be checkable against any
+  `Computation`, not only against one that inherited from it.
+- **Dependency-shape assertions** — "this node must depend on that one" — which
+  no amount of class structure expresses.
+- **Typed node values.** `sig.df_signals` is still `Any`, because values are
+  reached through `comp.v`, which is an `AttributeView`. Typing the *value* needs
+  the facade shape from the last row of the table, layered on top.
+
+## Proposed API
+
+### Layer 1: `ComputationBase`
+
+```python
+class ComputationBase(Computation):
+    """A Computation whose nodes are declared as class members."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        populate_computation_from_class(self, type(self), self, self._ignore_self)
+```
+
+`_ignore_self` stays a class attribute so the per-class opt-out that
+`@ComputationFactory(ignore_self=False)` provides has an equivalent.
+
+### Layer 2: structural contracts
+
+For computations not built by inheritance:
+
+```python
+Signal.check(comp)          # -> report, in the idiom of validate() and to_df()
+Signal.requires(depends_on={"df_signals": ["prices"]})   # dependency shape, opt-in
+```
+
+Two independent checks — node presence and kind, and dependency shape — usable
+separately or together, because an interface that pins wiring is sometimes what
+you want and usually is not.
+
+### Layer 3: typed node access
+
+```python
+sig = Signal.view(comp)     # facade; sig.df_signals is statically a DataFrame
+```
+
+Only the facade can type node values, since attribute access on a real class is
+checkable where string-keyed access is not. Worth designing now, but shippable
+last.
+
+## What this makes redundant downstream
+
+Consumers currently patch the decorator's output to restore what it loses:
+copying `__name__`, `__qualname__`, `__module__` and `__wrapped__`, setting a
+return annotation, and walking the class to re-attach node members. Under
+inheritance all of that is native and the shim can be deleted.
+
+There is also a real bug to fix while this is open, independent of the direction
+chosen. `functools.wraps(cls, updated=())` copies the **class body's**
+annotations onto the factory function, so a class declaring `prices: str = input_node()`
+produces a factory whose `__annotations__` claim it takes a `prices: str`
+parameter. It does not. Under inheritance the question disappears; if the
+decorator is kept as-is, the annotations should be set rather than inherited.
+
+## Caveats
+
+- **`copy()` loses the subclass.** It returns a plain `Computation`, so a typed
+  `Signal` becomes untyped after copying. Values survive. Fixable, and it should
+  be, since silently downgrading the type is worse than not having it.
+- **Deserialization loses the subclass.** Unavoidable: the deserializer has no
+  way to know which class produced the graph. Must be documented, and it argues
+  for the structural `check()` in layer 2 as the way to re-establish an interface
+  after a roundtrip.
+- **Two ways to define a computation.** The decorator and the base class would
+  coexist indefinitely. That is a genuine cost in documentation and in answering
+  "which should I use". The docs should recommend one — the base class — and
+  explain that the decorator remains supported.
+
+## Delivery phases
+
+Each phase leaves the branch green and is independently reviewable.
+
+- **Phase 1 — `ComputationBase`.** The class, tests covering equivalence with the
+  decorator, `self`-binding, and subclass composition. Docs page and a changelog
+  entry. No change to existing behaviour.
+- **Phase 2 — `copy()` preserves the subclass**, plus a test. Small and separable.
+- **Phase 3 — structural contracts.** `check()` returning a report in the
+  existing `ValidationReport` idiom, with node presence and kind. Dependency
+  shape as an opt-in second check.
+- **Phase 4 — typed node access.** The facade, and whatever generation or
+  declaration it needs to stay in step with the interface.
+- **Phase 5 — documentation.** Recommend the base class, document the decorator
+  as supported, and state the copy and serialization caveats plainly.
+
+## Testing approach
+
+Equivalence is the main assertion: for the same model expressed both ways, the
+generated node set, the edges and the computed values must match. That is cheap
+to write and is what protects the decorator from regressing while the base class
+is added.
+
+Typing itself needs a different kind of test, since the suite cannot assert what
+a checker infers. The practical option is a small fixture module of intentionally
+correct and intentionally wrong usages, checked in CI by the existing `ty` step,
+with the wrong ones expected to produce diagnostics. Without that, the typing
+guarantee is untested and will rot.
+
+## Risks and open questions
+
+- **Does the base class interact with `add_block` and repeated blocks?** Adding a
+  subclass instance as a block worked in the prototype. Using one as a repeated
+  block template was not tested, because those utilities are on an unmerged
+  branch. Needs checking before phase 1 lands.
+- **Metaclass conflicts.** Anyone whose computation class already has a metaclass
+  would now hit `Computation`'s. Unlikely, but it is a hard error when it
+  happens.
+- **`__init__` signature.** `ComputationBase.__init__` must pass executor
+  arguments through to `Computation.__init__` while also populating. Subclasses
+  that define their own `__init__` need a documented rule about calling
+  `super().__init__()`.
+- **Is one recommended way worth the churn?** Inheritance is better typed and
+  strictly more capable, but the decorator is what every existing example and
+  document uses. Migrating the documentation is most of the work and none of the
+  risk, and it should be a deliberate decision rather than a side effect.

--- a/docs/development/TYPED_COMPUTATIONS_PLAN.md
+++ b/docs/development/TYPED_COMPUTATIONS_PLAN.md
@@ -1,54 +1,45 @@
 # Design plan: typed and abstract computations
 
-Status: proposed, not implemented. This document is the design for review; no code
-has been written on this branch.
+Status: proposed, not implemented. No code has been written on this branch.
 
-## Recommendation
+Two things are being solved, and keeping them apart is the main decision here:
 
-Two independent things are being asked for, and separating them is the main
-decision in this document.
+1. **Interfaces** — declaring that a computation *is a* Signal, checking it, and
+   reading its nodes with real types. Defined over `Computation`, so it works with
+   every existing computation and needs no migration.
+2. **Typing the computation object** — `Signal()` should be a `Computation` to a
+   type checker. Only inheritance can do this, so it is a separate, later layer
+   that users opt into.
 
-**The interface — "this computation is a Signal" — should be defined over
-`Computation`, not over how the computation was built.** A contract is a
-statement about a graph: these nodes exist, this one is an input, that one is a
-calculation. Nothing about that depends on whether the graph came from a
-decorator, from inheritance, or from `add_node` calls in a loop. Defining it that
-way means the existing `@ComputationFactory` gets interfaces on day one, with no
-migration:
+## Scope
 
-```python
-class Signal(ComputationInterface):
-    prices = required_input()
-    df_signals = required_calc()
+**In scope**
 
-Signal.check(comp)      # -> report, over any Computation
-sig = Signal.view(comp) # -> typed facade; sig.df_signals is statically typed
-```
+- A declared contract: which nodes must exist, and whether each is an input or a
+  calculation. Optionally, which nodes a calculation must depend on.
+- Checking any `Computation` against a contract, with actionable reasons.
+- Statically typed access to a conforming computation's node values.
+- Declaring conformance at construction, for both declaration styles.
+- `ComputationBase`, so a computation can be declared by inheriting.
 
-This was prototyped against real loman and the same contract accepted
-decorator-built, inheritance-built and imperatively-built computations
-identically, rejecting a non-conforming one with reasons
-(`"missing node 'df_signals'"`, `"'prices' should be an input"`).
+**Out of scope**
 
-**Separately**, `loman.ComputationBase` lets a computation be declared by
-inheriting rather than decorating, which is the only way to give the computation
-*object itself* a usable static type:
+- Runtime checking of node *value* types. The contract is about graph shape.
+  Declared types drive the static facade; nothing asserts `isinstance` at compute
+  time. Revisit only if asked for.
+- Changing or deprecating `@ComputationFactory`. It keeps working, unchanged,
+  and gains interfaces for free.
+- Typing `comp.v` / `comp.s` and the other attribute views. String-keyed access
+  is untypeable; the facade exists precisely to sidestep it.
+- Generating interfaces from an existing computation.
 
-```python
-class Signal(ComputationBase):
-    prices = input_node()
+## Decided, with evidence
 
-    @calc_node
-    def df_signals(self, prices):
-        return prices * 2
-```
+These were measured, not reasoned about. They should not need relitigating.
 
-`@ComputationFactory` keeps working unchanged; both are additive.
-
-The reason the second one is needed at all is narrow and measurable. A class
-decorator that returns something other than the class **cannot be typed**, in any
-current checker, by design. The consequence today is that every legitimate use of
-a factory-built computation is a false positive:
+**A class decorator cannot be typed.** `@ComputationFactory class Signal` gives a
+symbol that checkers treat as the class, so every legitimate use of the result is
+a false positive:
 
 ```text
 error[unresolved-attribute]: Object of type `Signal` has no attribute `compute_all`
@@ -56,141 +47,68 @@ error[unresolved-attribute]: Object of type `Signal` has no attribute `insert`
 error[unresolved-attribute]: Object of type `Signal` has no attribute `v`
 ```
 
-Inheritance produces none of those, while still catching real mistakes, because
-the declared class genuinely *is* the type of the object you get back.
+Three separate escapes were tried and all fail: annotating the decorator as
+returning `type[Computation]`, adding `@overload` to `computation_factory`, and
+declaring `__new__` as returning `Computation`. Class-decorator return types are
+ignored by design. **Do not spend more time here** — anything that must keep the
+decorator working goes through the facade, not through the decorated name.
 
-The order matters for delivery: the interface layer is worth more, is not
-blocked on anything, and helps every existing user. `ComputationBase` is worth
-having, but only decorator users who also want the computation object typed have
-to adopt it.
+**The assignment form does type.** `Signal = computation_factory(Spec)` infers
+`Computation`, because it is an ordinary call. Worth documenting as a workaround;
+it discards the class identity, so it is not the destination.
 
-## Evidence
+**Contracts are construction-agnostic.** A prototype contract accepted
+decorator-built, inheritance-built and imperatively-built computations
+identically, and rejected a non-conforming one with reasons
+(`"missing node 'df_signals'"`, `"'prices' should be an input"`).
 
-Six shapes were measured under `ty`, each with a deliberate nonsense call to
-confirm the checker was really looking.
+**Inheritance works and is faithful.** `ComputationBase` prototyped against real
+loman produced identical nodes and identical results to the decorator, with
+`isinstance` working, declared nodes reachable as class attributes, name and
+docstring preserved without `functools.wraps`, and `self`-binding in calc nodes
+unaffected. Subclassing composes: a subclass inherits declared nodes, so an
+abstract computation is just a base class.
 
-| shape | inferred type | legitimate calls | nonsense caught |
-| --- | --- | --- | --- |
-| class decorator returning a factory function (today) | the class | **all error** | yes, for the wrong reason |
-| the same decorator applied by assignment | `Computation` | pass | yes |
-| class decorator returning `type[Computation]` | the class | error | — |
-| a class declaring `__new__` returning `Computation` | the class | error | — |
-| **inheritance** | the subclass | pass | yes |
-| **typed facade over a computation** | the facade | pass | yes, and node values are typed |
+### Two mechanism constraints
 
-Three findings matter more than the table.
+Both were found by testing and will silently degrade everything if missed.
 
-**Class-decorator return types are ignored regardless of what they are.** The
-third row is the control: annotating the decorator as returning
-`type[Computation]` changes nothing. This is long-standing, deliberate behaviour,
-so no annotation, overload or stub can fix the current shape. An earlier
-suggestion to add `@overload` to `computation_factory` was tested and does not
-work.
+- **`view()` must return `Self`, never `Any`.** With `Any`, the gradual type
+  flows through the annotated variable and every node access degrades to `Any`
+  with no error anywhere. Verified: with `Self`, `sig.df_signals` types as the
+  declared type; with `Any`, it types as `Any`.
+- **`required_input()` and `required_calc()` must be annotated `-> Any`,** the way
+  `dataclasses.field()` is. That lets `df_signals: DataFrame = required_calc()`
+  assign without complaint while the annotation governs attribute access.
 
-**Nor does `__new__`.** The fourth row is the last mechanism that could have
-rescued the decorator form: a class whose `__new__` is declared to return
-`Computation`. `ty` ignores that too. There is no way to make the decorated
-symbol itself type as a computation, so anything that needs the decorator to keep
-working must go through the facade rather than through the decorated name.
-
-**The facade works over anything.** It is an ordinary class, so its attributes
-type normally, and it takes a `Computation` rather than caring where the
-computation came from. That is what lets the interface layer serve decorator
-users without asking them to change how they build computations.
-
-**The assignment form does type correctly.** `Signal = computation_factory(Spec)`
-infers `Computation`, because it is an ordinary call rather than a class
-decorator. It is worth documenting as an immediate workaround for anyone blocked
-today, but it discards the class identity, so it is a stopgap and not the
-destination.
-
-## Prototype results
-
-`ComputationBase` was prototyped against real loman and compared with the
-existing decorator on the same model.
-
-- **Runtime is identical.** Same generated nodes, same computed result.
-- **Typing is correct.** `compute_all`, `insert` and `v` all resolve; a nonsense
-  attribute is still an error.
-- **`isinstance(s, Computation)` is true**, which the decorator cannot offer.
-- **Declared nodes are reachable as class attributes.** `Signal.prices` is an
-  `InputNode`. Consumers currently hand-roll this by walking the class and
-  calling `setattr` on the returned function.
-- **Name and docstring are preserved natively**, with no `functools.wraps`. That
-  also removes an existing bug, described below.
-- **`self`-binding in calc nodes still works**, so helper methods are unaffected.
-
-### Abstract computations fall out of it
-
-This ran as-is in the prototype:
-
-```python
-class AbstractSignal(ComputationBase):
-    prices = input_node()
-
-class ConcreteSignal(AbstractSignal):
-    @calc_node
-    def df_signals(self, prices):
-        return prices * 3
-```
-
-Both nodes are present on the instance, `isinstance(c, AbstractSignal)` is true,
-and `def run(sig: AbstractSignal)` type-checks at the call site. Subclassing *is*
-the declaration, and it is enforced at construction because construction is what
-populates the graph.
-
-What inheritance does **not** cover, and still needs machinery:
-
-- **Structural checking of a computation built some other way** — imperatively,
-  or by repeated blocks. An interface should be checkable against any
-  `Computation`, not only against one that inherited from it.
-- **Dependency-shape assertions** — "this node must depend on that one" — which
-  no amount of class structure expresses.
-- **Typed node values.** `sig.df_signals` is still `Any`, because values are
-  reached through `comp.v`, which is an `AttributeView`. Typing the *value* needs
-  the facade shape from the last row of the table, layered on top.
-
-## Proposed API
-
-The first two layers work over any `Computation`, whatever built it. Only the
-third asks a user to change how they declare one.
-
-### Layer 1: structural contracts
+## API
 
 ```python
 class Signal(ComputationInterface):
-    prices = required_input()
-    df_signals = required_calc()
+    """Any computation that behaves as a signal."""
 
-Signal.check(comp)      # -> report, in the idiom of validate() and to_df()
+    prices: pd.DataFrame = required_input()
+    df_signals: pd.DataFrame = required_calc(depends_on=["prices"])
 ```
 
-Two independent kinds of assertion — node presence and kind, and dependency shape
-— usable separately or together, because an interface that pins wiring is
-sometimes what you want and usually is not:
+One declaration serves three jobs — specification, checking, and typed access.
 
 ```python
-class Signal(ComputationInterface):
-    df_signals = required_calc(depends_on=["prices"])   # opt-in, not the default
+Signal.check(comp)      # -> report; reasons it does not conform, empty if it does
+Signal.view(comp)       # -> Signal; refuses a non-conforming computation
 ```
 
-The prototype's report is a list of reasons rather than a bare boolean, which is
-what makes it useful at a boundary: `"missing node 'df_signals'"`,
-`"'prices' should be an input"`.
+Verified behaviour of the facade under `ty`:
 
-### Layer 2: typed node access
+| expression | result |
+| --- | --- |
+| `sig = Signal.view(comp)` | `Signal` |
+| `sig.df_signals` | `pd.DataFrame` |
+| `sig.df_signals.not_a_frame_method()` | error |
+| `sig.not_declared` | error |
+| `Signal.check(comp)` | `list[str]` |
 
-```python
-sig = Signal.view(comp)     # facade; sig.df_signals is statically a DataFrame
-```
-
-Only the facade can type node values, since attribute access on a real class is
-checkable where string-keyed access is not. `view` checks conformance first and
-refuses a computation that does not satisfy the contract, so a typed handle
-cannot be obtained for a graph that would not support it.
-
-Together these two layers give a decorator user everything except a static type
-for the computation object:
+This is what a decorator user gets, with no migration:
 
 ```python
 @ComputationFactory
@@ -201,10 +119,24 @@ class MySignal:
     def df_signals(self, prices): ...
 
 
-sig = Signal.view(MySignal())   # typed, conformance-checked, no migration
+sig = Signal.view(MySignal())
 ```
 
-### Layer 3: `ComputationBase`
+### Declaring conformance at construction
+
+```python
+@ComputationFactory(implements=Signal)
+class MySignal: ...
+
+
+class MySignal(ComputationBase, implements=Signal): ...
+```
+
+Both are runtime checks that fail where the computation is defined rather than at
+the call site that needed it, reporting the contract's reasons. Neither changes
+the decorator's static type; that is settled above.
+
+### `ComputationBase`
 
 ```python
 class ComputationBase(Computation):
@@ -215,110 +147,108 @@ class ComputationBase(Computation):
         populate_computation_from_class(self, type(self), self, self._ignore_self)
 ```
 
-`_ignore_self` stays a class attribute so the per-class opt-out that
-`@ComputationFactory(ignore_self=False)` provides has an equivalent.
+`_ignore_self` is a class attribute, mirroring
+`@ComputationFactory(ignore_self=False)`.
 
-This is the layer that types the computation object itself, and the one that
-requires adopting a new declaration style. Worth having, and worth being last.
+## Phases
 
-### Declaring conformance at construction
+Each is independently reviewable and leaves the branch green.
 
-A factory can name the interfaces it claims, so a broken implementation fails
-where it is defined rather than at the call site that needed it:
+**Phase 1 — contracts.** `ComputationInterface`, `required_input`,
+`required_calc`, and `check()`.
+*Acceptance:* the same contract checks a decorator-built, inheritance-built and
+imperatively-built computation identically; a non-conforming computation reports
+every reason, not just the first; the report follows the `ValidationReport` idiom
+including `to_df()`. *Depends on:* nothing. *Size:* medium.
 
-```python
-@ComputationFactory(implements=Signal)
-class MySignal: ...
+**Phase 2 — the typed facade.** `view()`, checking conformance before returning.
+*Acceptance:* `sig.df_signals` types as the declared type under `ty`; an
+undeclared attribute is an error; `view` on a non-conforming computation raises
+with the reasons. Includes the typing fixture described below. *Depends on:*
+phase 1. *Size:* small.
 
+**Phase 3 — `ComputationBase`.** *Acceptance:* for one model expressed both ways,
+generated nodes, edges and computed values match exactly; `self`-binding works;
+a subclass inherits declared nodes; `isinstance` holds. *Depends on:* nothing.
+*Size:* medium.
 
-class MySignal(ComputationBase, implements=Signal): ...
-```
+**Phase 4 — `copy()` preserves the subclass.** *Acceptance:* `Signal().copy()` is
+a `Signal`, values intact. *Depends on:* phase 3. *Size:* small.
 
-Both are runtime checks — the static type of the decorator form is unaffected,
-for the reasons in the evidence section. The value is that the error arrives at
-construction with the contract's reasons attached.
+**Phase 5 — `implements=`.** Both declaration styles.
+*Acceptance:* a non-conforming implementation fails at construction with the
+contract's reasons. *Depends on:* phases 1 and 3. *Size:* small.
 
-## What this makes redundant downstream
+**Phase 6 — documentation.** Interfaces with both declaration styles, which is
+recommended for new code, and the caveats below stated plainly. *Depends on:* the
+rest. *Size:* small.
 
-Consumers currently patch the decorator's output to restore what it loses:
-copying `__name__`, `__qualname__`, `__module__` and `__wrapped__`, setting a
-return annotation, and walking the class to re-attach node members. Under
-inheritance all of that is native and the shim can be deleted.
-
-There is also a real bug to fix while this is open, independent of the direction
-chosen. `functools.wraps(cls, updated=())` copies the **class body's**
-annotations onto the factory function, so a class declaring `prices: str = input_node()`
-produces a factory whose `__annotations__` claim it takes a `prices: str`
-parameter. It does not. Under inheritance the question disappears; if the
-decorator is kept as-is, the annotations should be set rather than inherited.
-
-## Caveats
-
-- **`copy()` loses the subclass.** It returns a plain `Computation`, so a typed
-  `Signal` becomes untyped after copying. Values survive. Fixable, and it should
-  be, since silently downgrading the type is worse than not having it.
-- **Deserialization loses the subclass.** Unavoidable: the deserializer has no
-  way to know which class produced the graph. Must be documented, and it argues
-  for the structural `check()` in layer 1 as the way to re-establish an interface
-  after a roundtrip — which works precisely because the contract is defined over
-  `Computation` rather than over the class that built it.
-- **Two ways to define a computation.** The decorator and the base class would
-  coexist indefinitely. That is a genuine cost in documentation and in answering
-  "which should I use". Splitting the interface layer out of the base class
-  softens it considerably: the answer becomes "either, and interfaces work with
-  both", rather than "switch". The docs should still say which is recommended for
-  new code.
-
-## Delivery phases
-
-Each phase leaves the branch green and is independently reviewable.
-
-- **Phase 1 — structural contracts.** `ComputationInterface` and `check()`,
-  returning a report in the existing `ValidationReport` idiom, with node presence
-  and kind. Dependency shape as an opt-in second assertion. Works over any
-  `Computation`, so it lands value for existing `@ComputationFactory` users
-  without asking them to change anything, and it does not depend on any of the
-  phases below.
-- **Phase 2 — the typed facade.** `view()`, checking conformance before handing
-  back a typed handle. This is what gives decorator users typed node access.
-- **Phase 3 — `ComputationBase`.** The class, tests covering equivalence with the
-  decorator, `self`-binding, and subclass composition. Docs page and a changelog
-  entry. No change to existing behaviour.
-- **Phase 4 — `copy()` preserves the subclass**, plus a test. Small and separable,
-  and only meaningful once phase 3 exists.
-- **Phase 5 — conformance at construction.** `implements=` on both the decorator
-  and the base class, as a runtime check reporting the contract's reasons.
-- **Phase 6 — documentation.** Show interfaces working with both declaration
-  styles, say which is recommended for new code, and state the copy and
-  serialization caveats plainly.
+Phases 1 and 2 deliver most of the value and are not blocked by anything. If the
+work is cut short, stopping after phase 2 leaves something coherent and useful.
 
 ## Testing approach
 
-Equivalence is the main assertion: for the same model expressed both ways, the
-generated node set, the edges and the computed values must match. That is cheap
-to write and is what protects the decorator from regressing while the base class
-is added.
+Two kinds, because the suite cannot assert what a checker infers.
 
-Typing itself needs a different kind of test, since the suite cannot assert what
-a checker infers. The practical option is a small fixture module of intentionally
-correct and intentionally wrong usages, checked in CI by the existing `ty` step,
-with the wrong ones expected to produce diagnostics. Without that, the typing
-guarantee is untested and will rot.
+**Behaviour**, in the normal suite: contract checking across all three
+construction styles; every failure mode reporting all its reasons; equivalence
+between the decorator and `ComputationBase` on the same model.
 
-## Risks and open questions
+**Typing**, as a fixture module of intentionally correct and intentionally wrong
+usages, checked in CI by the existing `ty` step, with the wrong ones expected to
+produce diagnostics. Without this the typing guarantee is untested and will rot —
+and given the whole point of this work is static types, an untested typing
+guarantee is the failure mode to avoid.
 
-- **Does the base class interact with `add_block` and repeated blocks?** Adding a
-  subclass instance as a block worked in the prototype. Using one as a repeated
-  block template was not tested, because those utilities are on an unmerged
-  branch. Needs checking before phase 1 lands.
-- **Metaclass conflicts.** Anyone whose computation class already has a metaclass
-  would now hit `Computation`'s. Unlikely, but it is a hard error when it
-  happens.
-- **`__init__` signature.** `ComputationBase.__init__` must pass executor
-  arguments through to `Computation.__init__` while also populating. Subclasses
-  that define their own `__init__` need a documented rule about calling
-  `super().__init__()`.
-- **Is one recommended way worth the churn?** Inheritance is better typed and
-  strictly more capable, but the decorator is what every existing example and
-  document uses. Migrating the documentation is most of the work and none of the
-  risk, and it should be a deliberate decision rather than a side effect.
+## Caveats
+
+- **`copy()` loses the subclass** until phase 4: it returns a plain
+  `Computation`, so a typed `Signal` silently becomes untyped. Values survive.
+- **Deserialization loses the subclass**, unavoidably — the deserializer cannot
+  know which class built the graph. `check()` is the way to re-establish an
+  interface after a roundtrip, which works because contracts are defined over
+  `Computation`.
+- **Two ways to declare a computation** will coexist. Splitting interfaces out
+  softens this a lot: the answer to "which should I use" becomes "either, and
+  interfaces work with both". The docs should still name one for new code.
+
+## Fix while this is open
+
+Independent of the direction chosen: `functools.wraps(cls, updated=())` copies
+the **class body's** annotations onto the factory function, so a class declaring
+`prices: str = input_node()` produces a factory whose `__annotations__` claim it
+takes a `prices: str` parameter. It does not. Under inheritance the question
+disappears; if the decorator is kept as-is, annotations should be set rather than
+inherited.
+
+## Open questions
+
+- **`check()`'s return type.** A `list[str]` is easy to consume; a report object
+  matching `ValidationReport` is consistent with the rest of loman and gets
+  `to_df()` for free. Leaning to the report; the phase-1 acceptance criteria
+  assume it.
+- **Does `view()` snapshot or stay live?** A facade holding the computation reads
+  current values on each access, which is probably what people expect, but it
+  means a `Signal` can stop conforming after it was handed out.
+- **Interaction with repeated blocks.** Adding a `ComputationBase` subclass as a
+  block works; using one as a *repeated-block template* is untested, because
+  those utilities were on an unmerged branch when this was written. Check before
+  phase 3.
+- **Metaclass conflicts.** A computation class that already has a metaclass would
+  now meet `Computation`'s. Unlikely, but a hard error when it happens.
+- **Should interfaces compose?** `class Tradeable(Signal, Priced)` is natural to
+  reach for and needs a rule for merging contracts.
+
+## Evidence appendix
+
+Six shapes measured under `ty`, each with a deliberate nonsense call to confirm
+the checker was really looking.
+
+| shape | inferred type | legitimate calls | nonsense caught |
+| --- | --- | --- | --- |
+| class decorator returning a factory function (today) | the class | **all error** | yes, for the wrong reason |
+| the same decorator applied by assignment | `Computation` | pass | yes |
+| class decorator returning `type[Computation]` | the class | error | — |
+| a class declaring `__new__` returning `Computation` | the class | error | — |
+| inheritance | the subclass | pass | yes |
+| typed facade over a computation | the facade | pass | yes, and node values are typed |


### PR DESCRIPTION
Design plan only — no implementation. Draft so the API shape can be argued before any code.

Full plan: [`docs/development/TYPED_COMPUTATIONS_PLAN.md`](docs/development/TYPED_COMPUTATIONS_PLAN.md)

## Two problems, deliberately separated

**1. Interfaces.** Declare that a computation *is a* Signal, check it, and read its nodes with real types. Defined over `Computation`, so it works with **every existing computation and needs no migration** — including everything built with `@ComputationFactory` today.

```python
class Signal(ComputationInterface):
    prices: pd.DataFrame = required_input()
    df_signals: pd.DataFrame = required_calc(depends_on=["prices"])

Signal.check(comp)      # reasons it does not conform, over any Computation
sig = Signal.view(comp) # typed handle; sig.df_signals is statically a DataFrame
```

Prototyped against real loman: the same contract accepted decorator-built, inheritance-built and imperatively-built computations identically, and rejected a non-conforming one with reasons (`"missing node 'df_signals'"`, `"'prices' should be an input"`).

**2. Typing the computation object.** `Signal()` should be a `Computation` to a checker. Only inheritance can do this, so `ComputationBase` is a separate, later layer that users opt into rather than the headline.

## Settled, so it is not relitigated

**A class decorator cannot be typed.** Three escapes were tried and all fail: annotating the decorator as returning `type[Computation]`, adding `@overload` to `computation_factory`, and declaring `__new__` as returning `Computation`. Class-decorator return types are ignored by design. The plan says explicitly not to spend more time here — anything needing the decorator goes through the facade, not the decorated name.

Verified facade behaviour under `ty`:

| expression | result |
| --- | --- |
| `sig = Signal.view(comp)` | `Signal` |
| `sig.df_signals` | `pd.DataFrame` |
| `sig.df_signals.not_a_frame_method()` | error |
| `sig.not_declared` | error |

Two mechanism constraints found by testing, both of which degrade everything silently if missed: **`view()` must return `Self`, never `Any`** (with `Any` the gradual type flows through and every node access becomes `Any` with no error anywhere), and **`required_input`/`required_calc` must be annotated `-> Any`**, the way `dataclasses.field()` is, so the annotation governs attribute access.

## Scope and phases

In scope: contracts over graph shape, checking with reasons, typed node access, `implements=` at construction, and `ComputationBase`. Explicitly out: runtime checking of node *value* types, deprecating `@ComputationFactory`, typing `comp.v`, and generating interfaces from existing computations.

Six phases, each with acceptance criteria, dependencies and a size. **Phases 1 and 2 are unblocked and deliver most of the value** — stopping after the facade leaves something coherent and useful.

## Open questions

- `check()` returning `list[str]` versus a `ValidationReport`-style object with `to_df()` (leaning to the report)
- whether `view()` snapshots or stays live
- interaction with repeated blocks as a *template* — untested, since those utilities were unmerged when this was written
- whether interfaces should compose (`class Tradeable(Signal, Priced)`)
