### PR TITLE
Update README and documentation links for installation and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ make check
 
 ## 📖 Documentation
 
-- 📚 [Complete Documentation](http://loman.readthedocs.io/): Comprehensive guides and API reference
-- 🚀 [Quickstart Guide](http://loman.readthedocs.io/en/latest/user/quickstart.html): Get up and running in minutes
-- 💡 [User Guide](http://loman.readthedocs.io/en/latest/user/intro.html): In-depth concepts and strategies
+- 📚 [Complete Documentation](https://janushendersonassetallocation.github.io/loman/): Comprehensive guides and API reference
+- 🚀 [Quickstart Guide](https://janushendersonassetallocation.github.io/loman/user/quickstart/): Get up and running in minutes
+- 💡 [User Guide](https://janushendersonassetallocation.github.io/loman/user/intro/): In-depth concepts and strategies
 - 📊 [Interactive Examples](examples/): Real-world financial modeling examples
-- 🔧 [API Reference](http://loman.readthedocs.io/en/latest/api.html): Complete function and class documentation
+- 🔧 [API Reference](https://janushendersonassetallocation.github.io/loman/api/): Complete function and class documentation
 
 ## ☁️ Try Loman in Codespaces
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,13 @@ make check
 - 📚 [Complete Documentation](https://janushendersonassetallocation.github.io/loman/): Comprehensive guides and API reference
 - 🚀 [Quickstart Guide](https://janushendersonassetallocation.github.io/loman/user/quickstart/): Get up and running in minutes
 - 💡 [User Guide](https://janushendersonassetallocation.github.io/loman/user/intro/): In-depth concepts and strategies
-- 📊 [Interactive Examples](examples/): Real-world financial modeling examples
+- 📊 [Interactive Examples](https://janushendersonassetallocation.github.io/loman/notebooks/): Real-world financial modeling examples
 - 🔧 [API Reference](https://janushendersonassetallocation.github.io/loman/api/): Complete function and class documentation
+
+### Run Locally with Marimo
+```bash
+make marimo
+```
 
 ## ☁️ Try Loman in Codespaces
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ make check
 - ⚡ **Zero Setup** - Everything configured ready to go
 - 🎯 **VS Code Extensions** - Python, testing, and productivity extensions pre-installed
 
-
 ## 👥 Contributing
 
 We welcome contributions! 🎉

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Loman transforms how you build and maintain complex data processing pipelines by
 ```bash
 pip install loman
 ```
+More detailed instructions can be found at: [User Guide-Installation](https://janushendersonassetallocation.github.io/loman/user/install/)
 
 ### From source (development)
 
@@ -131,11 +132,6 @@ cd loman
 pip install -e .
 ```
 **Note**: Use `-e` flag for editable installation during development
-
-### Installation of Graphviz
-```bash
-(https://vscode.dev/github/nikjascrazzy/MyLoman/blob/feature/improve-documents/docs/user/install.md)
-```
 
 ## 🛠️ Development
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,12 @@ git clone https://github.com/janusassetallocation/loman.git
 cd loman
 pip install -e .
 ```
-
 **Note**: Use `-e` flag for editable installation during development
+
+### Installation of Graphviz
+```bash
+(https://vscode.dev/github/nikjascrazzy/MyLoman/blob/feature/improve-documents/docs/user/install.md)
+```
 
 ## 🛠️ Development
 


### PR DESCRIPTION
Root README used to link to read http://loman.readthedocs.io, which is outdated, linking to github pages which is updated on every release.

Related pull request where I have updated the user guide-installation page #378 

