### PR TITLE
ci: install Graphviz in the floors job

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -53,6 +53,22 @@ jobs:
           version: "0.11.7"
           python-version: "3.11"
 
+      # This job runs the whole suite, which includes the visualization and
+      # widget tests, and those shell out to Graphviz's `dot`. Everywhere else
+      # that runs them goes through `make test`, whose `install` prerequisite
+      # fires the repo's `pre-install` hook and installs Graphviz; this job
+      # deliberately bypasses make, because `make test` resolves from uv.lock
+      # and the whole point here is to resolve from the declared floors
+      # instead. Bypassing make dropped the hook with it, so the binary was
+      # never installed and 121 tests failed with "GraphViz's executables not
+      # found" -- an environment gap reported as if the floors were broken.
+      #
+      # The pandas job below needs no such step: its module list is the
+      # version-sensitive tests only, none of which render a graph.
+      - name: Install Graphviz
+        if: steps.changed.outputs.run == 'true'
+        run: make install-graphviz
+
       # benchmarks/ and stress/ are excluded to match `make test`: the benchmark
       # suite needs pytest-benchmark, which the benchmark target installs ad-hoc
       # rather than declaring, and stress tests are opt-in via their marker.


### PR DESCRIPTION
Fixes the `floors resolve and pass on 3.11` job in the `compatibility` workflow —
[run 33825865575](https://github.com/janushendersonassetallocation/loman/actions/runs/33825865575/job/100878272047),
121 failed / 1420 passed.

### Cause

Every failure was the same one:

```
pydotplus.graphviz.InvocationException: GraphViz's executables not found
```

The floors job runs the whole suite, which includes `tests/test_visualization.py`
and `tests/test_ui_widget.py`. Those render by shelling out to Graphviz's `dot`,
and the binary was never installed on the runner.

Everywhere else that runs them goes through `make test`, whose `install`
prerequisite fires the repo's `pre-install` hook in
`.rhiza/make.d/00-additional-deps.mk` and installs Graphviz. This job bypasses
make deliberately — `make test` resolves from `uv.lock`, and resolving from the
*declared floors* instead is the entire point of the job — but bypassing make
dropped the hook along with it.

The `pandas` jobs in the same workflow also skip the hook (`make test-compat`
depends on `install-uv`, not `install`) and stayed green, because their module
list is the version-sensitive serialization tests only, none of which render a
graph. That's why the gap only ever showed up here.

### Fix

One step, before the test step:

```yaml
- name: Install Graphviz
  if: steps.changed.outputs.run == 'true'
  run: make install-graphviz
```

This reuses the installer the repo already has (`scripts/install-graphviz.sh`),
which retries transient failures, falls back between package managers, and
verifies `dot` actually appeared rather than trusting the installer's exit
status. No equivalent step is added to the `pandas` jobs, for the reason above.

### Verification

Ran the job's exact pytest invocation locally on Python 3.11 with `dot` present:

```
1541 passed, 30 warnings in 50.58s
```

1541 = the 1420 that passed in CI + the 121 that failed. So Graphviz was the sole
cause and **the declared floors themselves are fine** — nothing in `pyproject.toml`
needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
