### PR TITLE
chore: satisfy the four pyproject requirements rhiza 1.x added

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,14 +86,11 @@ efficient = [
 ]
 
 [dependency-groups]
-dev = [
-    "ruff>=0.12.0",
-    "marimo>=0.15",
-    "scipy>=1.16.3",
-    # test_ui_value, test_ui_viewmodel and test_visualization import hypothesis at
-    # module scope, so plain `make test` cannot collect them without it. The
-    # hypothesis-test target passes `--with hypothesis`, which only covers itself.
-    "hypothesis>=6.98.0",
+# `test` holds exactly what `pytest tests` needs to collect and run, and nothing
+# else. It is split out because rhiza's pyproject gate requires a group of that
+# name listing pytest, but the split earns its keep on its own: a CI job that only
+# runs the suite can ask for the runner without also resolving ruff and marimo.
+test = [
     # The make targets provision the runner ad-hoc with `uv run --with pytest`,
     # which leaves it undeclared for anything not going through them -- notably
     # `uv run --all-groups ... pytest`, which fails with "Failed to spawn:
@@ -102,13 +99,52 @@ dev = [
     "pytest>=8.0",
     "pytest-mock>=3.14",
     "pytest-timeout>=2.3",
+    # test_ui_value, test_ui_viewmodel and test_visualization import hypothesis at
+    # module scope, so plain `make test` cannot collect them without it. The
+    # hypothesis-test target passes `--with hypothesis`, which only covers itself.
+    "hypothesis>=6.98.0",
+]
+
+# Everything a contributor needs, which is the test group plus the tooling that is
+# not part of running the suite. `include-group` rather than a second copy of the
+# runner pins: `--group dev` and `--all-groups` both still resolve pytest, so no
+# caller had to change when the group above was carved out.
+dev = [
+    { include-group = "test" },
+    "ruff>=0.12.0",
+    "marimo>=0.15",
+    # Imported by the notebooks under docs/notebooks/, not by the suite.
+    "scipy>=1.16.3",
 ]
 
 [project.urls]
 Homepage = "https://github.com/janusassetallocation/loman"
+# The canonical spelling of the org, which `Homepage` predates: janusassetallocation
+# still resolves, but only as a 301 to this one. Required by rhiza's pyproject gate
+# (pytest_rhiza.checks.test_pyproject.TestProjectUrls) since 1.x.
+Repository = "https://github.com/janushendersonassetallocation/loman"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/loman"]
+
+# Without this table bump-my-version finds no config in any of the four filenames
+# it searches, and does not fail: it falls back to `git describe` and reports the
+# newest reachable tag as the current version. A release is then cut relative to
+# that number rather than the one in this file -- which is how a project sitting
+# at 0.7.0 gets offered "minor -> v0.7.0", a version it has already published.
+#
+# Deliberately three flags and no `current_version`: once the table exists,
+# bump-my-version reads and rewrites PEP 621 [project].version natively, so
+# restating the number here would only give it somewhere to go stale. There are no
+# [[tool.bumpversion.files]] entries for the same reason -- 0.7.0 appears in
+# exactly one place in this repo, seven lines up.
+[tool.bumpversion]
+allow_dirty = false
+# The release flow folds the changelog into the bump commit and tags that commit
+# itself, so a bare `bump-my-version bump` must not add a second commit or a
+# duplicate tag.
+commit = false
+tag = false
 
 [tool.deptry.per_rule_ignores]
 # pyarrow is loaded by name through loman._extras.require, so there is no import

--- a/uv.lock
+++ b/uv.lock
@@ -3,10 +3,10 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version < '3.14' and sys_platform == 'emscripten'",
@@ -18,8 +18,8 @@ name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform != 'emscripten'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -63,7 +63,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "python_full_version < '3.15' and implementation_name != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -666,6 +666,12 @@ dev = [
     { name = "ruff" },
     { name = "scipy" },
 ]
+test = [
+    { name = "hypothesis" },
+    { name = "pytest" },
+    { name = "pytest-mock" },
+    { name = "pytest-timeout" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -693,6 +699,12 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "ruff", specifier = ">=0.12.0" },
     { name = "scipy", specifier = ">=1.16.3" },
+]
+test = [
+    { name = "hypothesis", specifier = ">=6.98.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-mock", specifier = ">=3.14" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
 ]
 
 [[package]]
@@ -1123,7 +1135,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1526,7 +1538,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.15' and implementation_name == 'pypy' and sys_platform != 'emscripten'" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -1712,8 +1724,8 @@ name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform != 'emscripten'" },
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
@@ -1761,8 +1773,8 @@ name = "uvicorn"
 version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
-    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [


### PR DESCRIPTION
Stacks onto #403 rather than master: the `Rhiza repository checks` job only asserts these four things once the repo is on rhiza 1.x, so the fix belongs on that branch.

Closes #406.

## What was failing

`4 failed, 26 passed, 4 skipped` in `pytest_rhiza.checks.test_pyproject`:

- `TestProjectUrls::test_repository_configured` — `[project.urls]` has no `Repository`
- `TestDependencyGroups::test_test_group_present` — no `test` group
- `TestDependencyGroups::test_test_group_includes_pytest` — consequently no pytest in one
- `TestBumpversionConfigIsDiscoverable::test_a_discoverable_config_exists` — no `[tool.bumpversion]`

Two further bumpversion assertions were **skipped** because the table did not exist; they run and pass now.

## The three changes

**`Repository` URL.** Added with the canonical org spelling. `Homepage` still says `janusassetallocation`, which resolves — but only as a 301 to `janushendersonassetallocation`. I left it alone deliberately: the old name is also in five README links, so renaming it here and nowhere else would swap a redirect for a contradiction. Worth a separate sweep.

**`test` dependency group.** Holds the four packages `pytest tests` actually needs — pytest, pytest-mock, pytest-timeout, hypothesis — with `dev` pulling it in via `{ include-group = "test" }` rather than repeating the pins. ruff, marimo and scipy stay in `dev`; scipy is imported by `docs/notebooks/`, not by the suite. No call site had to change: CI resolves with `--all-groups`, and `--group dev` still reaches the runner transitively.

**`[tool.bumpversion]`.** The one with real consequences. bump-my-version searches four filenames and, finding none, does not fail — it falls back to `git describe` and reports the newest reachable tag as the current version, so a release is cut relative to that instead of `[project].version`.

Right now the two agree (`v0.7.0` is both the latest tag and the declared version), which is exactly why this has been invisible. They diverge the moment a bump lands before its tag, or on a shallow checkout.

Three flags, no `current_version`, no `[[tool.bumpversion.files]]`:

```toml
[tool.bumpversion]
allow_dirty = false
commit = false
tag = false
```

With the table present, bump-my-version reads and rewrites PEP 621 `[project].version` natively, so restating the number would only give it somewhere to go stale — and `0.7.0` appears in exactly one place in this repo. `commit`/`tag` stay false because the release flow makes the commit and the tag itself.

## About the uv.lock diff

Only ~12 lines are the new group. The rest — dropped `sys_platform != 'emscripten'` markers, reordered `resolution-markers` — is the `uv-lock` hook's own output, not a hand edit.

That drift **predates this PR**: `prek run uv-lock --all-files` rewrites the file exactly the same way on an untouched tree, and byte-for-byte matches `uv@0.12.9 lock`. It only passed in CI on #403 because nothing the hook watches had changed there.

## Verified locally

| Check | Result |
|---|---|
| `pytest --pyargs pytest_rhiza.checks.test_pyproject` | **27 passed** (was 4 failed / 20 passed / 3 skipped) |
| full `Rhiza repository checks` set (5 modules) | **34 passed** |
| `uv run --all-extras --all-groups pytest tests` | **1570 passed** |
| `--no-default-groups --group test ... --collect-only` | **1570 collected** — the new group stands alone |
| `bump-my-version show-bump` | reads `0.7.0` from `[project].version`; offers 0.7.1 / 0.8.0 / 1.0.0 |
| `deptry src tests` | no dependency issues |
| `prek run` — check-toml, validate-pyproject, uv-lock, check-managed-files, check-rhiza-config | all pass |

Nothing outside `pyproject.toml` and `uv.lock` is touched. `src/` is untouched.

Does not address the other three decisions in #403 — #404 (ruff), #405 (`ty`), #407 (floors/Graphviz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
