### PR TITLE
docs: describe the optional extras on the installation page

### DIFF
--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -12,6 +12,28 @@ If you don't have [pip](https://pip.pypa.io) installed (tisk tisk!),
 [this Python installation guide](http://docs.python-guide.org/en/latest/starting/installation/)
 can guide you through the process.
 
+## Optional extras
+
+Two features are packaged as extras, so a plain `pip install loman` stays small. Neither
+is needed for the core computation engine, and nothing in a bare `import loman` imports
+either one — both are loaded lazily, at the point you use the feature.
+
+| Extra | Install | What it adds |
+|---|---|---|
+| `ui` | `pip install 'loman[ui]'` | `comp.widget()`, the live notebook graph — see [The Interactive Widget](features/querying/interactive_widget.md) |
+| `efficient` | `pip install 'loman[efficient]'` | Parquet storage for DataFrames when saving a computation |
+
+Both together:
+
+```bash
+$ pip install 'loman[ui,efficient]'
+```
+
+`efficient` is a storage-format choice rather than a capability: without it, saved frames
+are written as `.npy`, which is numpy's own format and needs no extra package. Install it
+when you want the saved data readable by other tools; a frame pyarrow cannot represent
+falls back to the default encoding rather than failing the save.
+
 ## Dependency on graphviz
 
 Loman uses the [graphviz](http://www.graphviz.org/) tool, and the Python [graphviz library](https://pypi.python.org/pypi/graphviz) to draw dependency graphs. If you are using Continuum's excellent [Anaconda Python](https://www.continuum.io/downloads) distribution (recommended), then you can install them by running these commands:


### PR DESCRIPTION
The `ui` and `efficient` extras were each documented only where the feature they enable
is documented — `loman[ui]` on the [Interactive Widget](docs/user/features/querying/interactive_widget.md)
page, and `efficient` in a `pyproject.toml` comment. The installation guide, which is
where someone goes to find out what to install, listed neither.

## What this adds

A short "Optional extras" section on `docs/user/install.md`: a two-row table, the
combined install line, and the point that neither extra is imported by a bare
`import loman` — both load lazily at the point the feature is used. That last point is
repeated from the widget page on purpose: it is the question someone asks while deciding
what to install, so it belongs where that decision happens.

It also spells out the thing about `efficient` that is easy to get wrong: it is a
**storage-format choice, not a capability**. Without it, saved frames are written as
`.npy` — numpy's own format, no extra package needed — and a frame pyarrow cannot
represent falls back to the default encoding rather than failing the save. Install it to
make saved data readable by other tools, not to make saving work.

## Verification

- `tests/test_docs.py` — 7 passed. The new fences are `bash`, so nothing new is executed,
  but the file is in the tree that test walks.
- The new relative link (`features/querying/interactive_widget.md`) resolves in the built
  book: the build still reports exactly **one** warning, and it is the pre-existing one —
  `dev/release.md:12` linking to `../../CHANGELOG.md`, which sits outside `docs_dir`.
  Untouched here; worth its own fix.

## Scope

`docs/user/install.md` only. Nothing else in the repo is touched.

Separately, and for the record: the three `UI_EXTRA_*` design documents that used to be
in the nav are already gone. The nav entries were removed in #403 because `book-nav`
(new in rhiza 1.x) flagged them — the files were never on `master`, so the published site
had three 404s in its Developer menu since #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
