### PR TITLE
fix(docs): render the README on the Home page instead of dumping it as text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-<div align="center">
+<div align="center" markdown="1">
 
 # Loman
 
@@ -211,7 +211,7 @@ Whether you're fixing bugs, adding features, or improving documentation, your he
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 ⭐ **If you find Loman useful, please consider giving it a star!** ⭐
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,14 @@ plugins:
             show_signature_annotations: true
 
 markdown_extensions:
+  # Required for README.md to render on the Home page. docs/index.md pulls the README
+  # in with a pymdownx snippet, and the README wraps its header and footer in
+  # <div align="center"> for GitHub. Python-Markdown leaves markdown inside a
+  # block-level HTML element alone unless md_in_html is enabled *and* the element
+  # carries markdown="1" -- so without this the whole block rendered as literal text,
+  # badges and headings included. GitHub parses it either way, which is why the same
+  # file looked right there and wrong in the book.
+  - md_in_html
   - mkdocs_graphviz:
       node_color: "000000"
       node_fontcolor: "000000"


### PR DESCRIPTION
The published Home page shows the README's **raw markdown** — `# Loman ### Manage complex
calculation flow...` as one centred paragraph, every badge as a literal
`[![...](...)](...)`, the whole page unreadable.

## Cause

`docs/index.md` is a one-line pymdownx snippet that pulls in `README.md`:

```
--8<-- "README.md"
```

The README wraps its header and footer in `<div align="center">` so GitHub centres them.
**Python-Markdown does not parse markdown inside a block-level HTML element** — it needs
the `md_in_html` extension enabled *and* a `markdown="1"` attribute on the element.
Neither was present, so everything between the div tags passed through as text.

GitHub parses markdown inside HTML blocks regardless, which is why the same file looks
right there and wrong in the book — and why this has gone unnoticed.

## Fix

Both halves are required, so both are here:

- **`md_in_html`** added to `markdown_extensions` in `mkdocs.yml`. It is already in the
  template's `docs/mkdocs-base.yml`, but this repo's `mkdocs.yml` carries no `INHERIT:`,
  so it gets none of that file. The base file warns about exactly this: *"a child that
  omits `INHERIT:` gets none of this, and nothing says so."*
- **`markdown="1"`** on the README's two centred divs (lines 2 and 214).

GitHub drops unknown attributes when it sanitises HTML, and parses markdown inside HTML
blocks natively, so its rendering is unchanged — visible on this PR's own page, which
renders the modified README.

## Verified on the built page

| Check | Before | After |
|---|---|---|
| `<h1>` containing "Loman" | absent | present |
| Image references rendered as `<img>` | 0 of 17 | **17 of 17** |
| Literal `[![` left on the page | many | **0** |

The build's single remaining warning is unchanged and unrelated: `release.md`'s link to
`../../CHANGELOG.md`, which sits outside `docs_dir`.

## Note on `INHERIT`

Adopting the template's base config wholesale would pick up `md_in_html` and more, but it
also replaces theme, plugin and extension settings this repo has customised. That is a
larger change with its own review; this PR fixes the rendering without taking it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
