### PR TITLE
fix: remove a stale type: ignore and document value_eq's broad catches

### DIFF
--- a/src/loman/ui/widget.py
+++ b/src/loman/ui/widget.py
@@ -349,7 +349,7 @@ class ComputationWidget(anywidget.AnyWidget):
         return self.computation.draw(
             self._root,
             node_transformations=transformations,
-            **options,  # type: ignore[arg-type]
+            **options,
         )
 
     @contextmanager

--- a/src/loman/util.py
+++ b/src/loman/util.py
@@ -815,6 +815,9 @@ def value_eq(a: Any, b: Any) -> bool:
         try:
             return bool(np.array_equal(a, b, equal_nan=True))
         except Exception:
+            # ``equal_nan=True`` raises on an object-dtype or ragged array, where
+            # numpy cannot decide what a NaN is. Reporting "not equal" is the safe
+            # direction -- see the note on the default comparison below.
             return False
 
     # Default comparison; ensure a single boolean
@@ -825,4 +828,10 @@ def value_eq(a: Any, b: Any) -> bool:
             return bool(np.all(result))
         return bool(result)
     except Exception:
+        # An arbitrary object's ``__eq__`` may raise, and its caller is
+        # ``Computation.insert``, which uses this only to skip a redundant write.
+        # "Not equal" therefore means the value is written and descendents marked
+        # stale -- a recomputation that was not needed, rather than a stale graph
+        # that looks up to date. Letting the exception escape would instead fail an
+        # insert over a comparison the caller never asked to be able to fail.
         return False


### PR DESCRIPTION
Two quick fixes from the quality assessment in #414, one per commit.

## `fix(types)` — remove a stale suppression (#418)

`src/loman/ui/widget.py:352` carried `# type: ignore[arg-type]` on the `**options` splat, and `ty` flagged it as an unused blanket directive — the underlying signature has been tightened since it was added. A stale ignore is worse than none, because it keeps hiding a *real* `arg-type` error if one is reintroduced at that call site.

`make typecheck` reported "Found 1 diagnostic" before this change and "All checks passed!" after.

## `docs(util)` — say why `value_eq` swallows comparison errors (#420)

Both broad catches in `value_eq` returned `False` with no stated reason. The intent is defensible, but it was unwritten — and every other broad catch in the codebase already carries its rationale (`computeengine.py:692` logs via `LOG.exception`; `transformer.py:1049` is an optional-extra guard; `computation.py:831` has a `pragma` note; `ui/value.py:81` explains that a broken `__repr__` must not break the detail panel). These two were the exception.

The rationale comes from the call site rather than from guessing at intent. `value_eq` has exactly one caller — `Computation.insert` at `computeengine.py:1140` — which uses it only to skip a redundant write on an `UPTODATE` node. So "not equal" means the value is written and descendents marked `STALE`: a recomputation that was not needed, rather than a stale graph that looks up to date. That asymmetry is what makes swallowing correct here, and letting the exception escape would instead fail an insert over a comparison the caller never asked to be able to fail.

No behaviour change in either commit — one deleted comment and two added ones.

## Verification

| Gate | Result |
| --- | --- |
| `make fmt` | PASS — 21/21 hooks |
| `make typecheck` | PASS — 0 diagnostics (was 1) |
| `make test` | PASS — 1542 passed, coverage 98.94%, unchanged |

Closes #418
Closes #420
