### PR TITLE
test: close the coverage gaps outside the transformer (98.94% -> 99.25%)

### DIFF
--- a/tests/test_api_compat.py
+++ b/tests/test_api_compat.py
@@ -266,6 +266,46 @@ class TestReleasedCallPatternsStillWork:
 
         assert (Computation.__getstate__, Computation.__setstate__) == before
 
+    def test_write_dill_old_blanks_a_node_marked_not_to_serialize(self, tmp_path):
+        """``serialize=False`` still means the value does not travel.
+
+        The deprecated path applies the ``__serialize__`` tag rule itself rather
+        than going through ``__getstate__``, which it has deleted for the
+        duration of the write. So the rule is implemented twice, and only the
+        other copy was covered.
+        """
+        import dill  # nosec B403
+
+        from loman import States
+
+        comp = Computation()
+        comp.add_node("kept", value=1)
+        comp.add_node("dropped", value=2, serialize=False)
+        path = tmp_path / "comp.dill"
+
+        with pytest.warns(DeprecationWarning, match="write_dill_old"):
+            comp.write_dill_old(str(path))
+
+        with path.open("rb") as f:
+            loaded = dill.load(f)  # nosec B301  # noqa: S301
+
+        assert loaded.v.kept == 1
+        assert loaded.state("dropped") == States.UNINITIALIZED
+
+    def test_write_dill_old_accepts_an_open_file(self, tmp_path):
+        """A file object is written to directly, as the signature promises."""
+        import dill  # nosec B403
+
+        comp = Computation()
+        comp.add_node("a", value=42)
+        path = tmp_path / "comp.dill"
+
+        with path.open("wb") as f, pytest.warns(DeprecationWarning, match="write_dill_old"):
+            comp.write_dill_old(f)
+
+        with path.open("rb") as f:
+            assert dill.load(f).v.a == 42  # nosec B301  # noqa: S301
+
 
 class TestWriteJsonOutputShape:
     """write_json still produces the document shape people parse."""

--- a/tests/test_byos.py
+++ b/tests/test_byos.py
@@ -16,7 +16,7 @@ import pytest
 from loman import Computation
 from loman.exception import SerializationError
 from loman.serialization import SerializationProfile
-from loman.serialization.blobs import MANIFEST_NAME, BlobStore
+from loman.serialization.blobs import MANIFEST_NAME, BlobStore, MemoryBlobStore
 
 LARGE = 20_000
 
@@ -484,3 +484,102 @@ class TestCustomTransformerWithAStore:
 
         assert store.writes
         assert restored.v.m == matrix
+
+
+class TestMemoryBlobStore:
+    """The store that ships as the worked example of the interface.
+
+    ``MemoryBlobStore`` is exported from ``loman.serialization`` and named in the
+    paper alongside ``DirBlobStore`` and ``ZipBlobStore``, but the suite had
+    always brought its own store --- ``RecordingStore`` above --- so nothing
+    exercised the one users are pointed at.
+    """
+
+    def test_a_fresh_store_starts_empty(self):
+        """Constructed with no argument, it owns a new dict."""
+        assert MemoryBlobStore().data == {}
+
+    def test_it_adopts_a_supplied_dict(self):
+        """Given a dict, it writes into that one rather than a copy."""
+        backing = {}
+        store = MemoryBlobStore(backing)
+        store.write_blob("k", b"payload")
+
+        assert backing == {"k": b"payload"}
+
+    def test_a_blob_round_trips(self):
+        """What was written under a key is what comes back."""
+        store = MemoryBlobStore()
+        store.write_blob("k", b"payload")
+
+        assert store.read_blob("k") == b"payload"
+
+    def test_a_missing_key_names_itself(self):
+        """A key that was never written raises, quoting the key."""
+        with pytest.raises(SerializationError, match="No blob stored under 'absent'"):
+            MemoryBlobStore().read_blob("absent")
+
+    def test_it_works_as_a_real_store(self, tmp_path):
+        """It routes a node's values out of the container like any other store."""
+        store = MemoryBlobStore()
+        comp = Computation()
+        comp.add_node("big", value=np.arange(LARGE, dtype="float64"), store="warehouse")
+
+        comp.save(str(tmp_path / "c.loman"), stores={"warehouse": store})
+        restored = Computation.load(str(tmp_path / "c.loman"), stores={"warehouse": store})
+
+        assert store.data
+        assert np.array_equal(restored.v.big, np.arange(LARGE, dtype="float64"))
+
+
+class TestRawBytesPayload:
+    """``put_blob`` takes bytes as well as a writer callable.
+
+    The callable form is what the built-in transformers use, so it is the only
+    one the suite reached. Both are documented on ``put_blob``, and a transformer
+    that already holds its bytes has no reason to wrap them in a writer.
+    """
+
+    def test_bytes_are_stored_and_returned(self, tmp_path):
+        """A transformer handing over raw bytes round-trips through a store."""
+        from loman.serialization import ComputationSerializer, CustomTransformer
+
+        class Doc:
+            """A user type that is already a bag of bytes."""
+
+            def __init__(self, raw):
+                self.raw = raw
+
+            def __eq__(self, other):
+                return isinstance(other, Doc) and other.raw == self.raw
+
+        class DocTransformer(CustomTransformer):
+            """Encodes a Doc by handing its bytes straight to put_blob."""
+
+            @property
+            def name(self):
+                return "doc"
+
+            def to_dict(self, transformer, o):
+                return {"data": transformer.put_blob(o.raw, codec="bin")}
+
+            def from_dict(self, transformer, d):
+                return Doc(transformer.get_blob(d["data"]))
+
+            @property
+            def supported_direct_types(self):
+                return [Doc]
+
+        doc = Doc(b"\x00\xff" * LARGE)
+        comp = Computation()
+        comp.add_node("d", value=doc, store="warehouse")
+
+        serializer = ComputationSerializer()
+        serializer.register(DocTransformer())
+        store = MemoryBlobStore()
+
+        comp.save(str(tmp_path / "c.loman"), serializer=serializer, stores={"warehouse": store})
+        restored = Computation.load(str(tmp_path / "c.loman"), serializer=serializer, stores={"warehouse": store})
+
+        assert store.data
+        assert restored.v.d == doc

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -663,6 +663,34 @@ class TestNoStoreAvailable:
         assert manifest["nodes"][0]["value"].get("encoding") != "npy"
 
 
+class TestMissingDestinationDirectory:
+    """A destination whose parent does not exist is reported as such.
+
+    Both containers build into a sibling ``.tmp`` first, so without the check
+    the error names a temporary file the caller never asked for and never sees.
+    """
+
+    def test_zip_save_names_the_missing_directory(self, tmp_path):
+        """Saving a .loman file names the directory, not the temporary."""
+        comp = _sample_computation()
+        target = tmp_path / "no_such_dir" / "c.loman"
+
+        with pytest.raises(SerializationError, match="does not exist") as excinfo:
+            comp.save(str(target))
+
+        message = str(excinfo.value)
+        assert "no_such_dir" in message
+        assert ".tmp" not in message
+
+    def test_dir_save_names_the_missing_directory(self, tmp_path):
+        """The directory container reports it the same way."""
+        comp = _sample_computation()
+        target = tmp_path / "no_such_dir" / "c_dir"
+
+        with pytest.raises(SerializationError, match="does not exist"):
+            comp.save(str(target), container="dir")
+
+
 class TestBlobReaderErrors:
     """Reading a blob the manifest describes but nothing can supply."""
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -7,6 +7,7 @@ import json
 import math
 from collections.abc import Iterable
 from dataclasses import dataclass
+from zoneinfo import ZoneInfo
 
 import attrs
 import numpy as np
@@ -1887,6 +1888,9 @@ AWKWARD_VALUES = {
     "bytearray": bytearray(b"\x01\x02"),
     "decimal": decimal.Decimal("1.10"),
     "datetime": datetime.datetime(2020, 1, 1, 12, 30),
+    # A named zone, not just an offset: the encoding records tzinfo.key so the
+    # zone survives rather than collapsing to whatever offset applied that day.
+    "zoned_datetime": datetime.datetime(2020, 1, 1, 12, 30, tzinfo=ZoneInfo("Europe/London")),
     "date": datetime.date(2020, 1, 1),
     "time": datetime.time(12, 30, 15),
     "timedelta": datetime.timedelta(days=1, microseconds=5),
@@ -1948,6 +1952,38 @@ def test_awkward_value_produces_strict_json(label):
     text = ComputationSerializer().dumps(comp)
 
     json.loads(text, parse_constant=_reject)
+
+
+class TestNamedTimezonesSurvive:
+    """A zone is not the same thing as the offset it happened to have.
+
+    ``==`` on two aware datetimes compares instants, so a round-trip that
+    silently replaced ``Europe/London`` with a fixed ``+00:00`` would still
+    compare equal in the table above. These assert the zone itself.
+    """
+
+    def test_the_zone_name_is_recorded(self):
+        """The encoding carries ``tzinfo.key``, not just the ISO offset."""
+        t = default_computation_transformer()
+        encoded = t.to_dict(datetime.datetime(2020, 6, 1, 12, 0, tzinfo=ZoneInfo("Europe/London")))
+
+        assert encoded["tz"] == "Europe/London"
+
+    def test_the_zone_name_is_restored(self):
+        """It comes back as the same named zone, not a fixed offset."""
+        original = datetime.datetime(2020, 6, 1, 12, 0, tzinfo=ZoneInfo("Europe/London"))
+        t = default_computation_transformer()
+        restored = t.from_dict(t.to_dict(original))
+
+        assert restored == original
+        assert restored.tzinfo.key == "Europe/London"
+
+    def test_a_plain_offset_records_no_zone(self):
+        """A datetime with no named zone carries no ``tz`` field."""
+        t = default_computation_transformer()
+        encoded = t.to_dict(datetime.datetime(2020, 6, 1, 12, 0, tzinfo=datetime.UTC))
+
+        assert "tz" not in encoded
 
 
 class TestDictKeyFidelity:


### PR DESCRIPTION
Follows #422. Together the two take the suite from 98.94% to **99.94%**, with three lines left deliberately.

Fifteen lines across four modules. Each was picked because it is *shipped behaviour that nothing held*, not because it was a branch that happened to be missed.

## `MemoryBlobStore` had no test at all

This is the one worth reading twice. `MemoryBlobStore` is exported from `loman.serialization`, its own docstring calls it "a worked example of the interface", and `docs/paper/loman.tex:652` names it alongside `DirBlobStore` and `ZipBlobStore` as one of the three stores that ship.

`grep MemoryBlobStore tests/` returned nothing. The suite has always brought its own store — `RecordingStore` in `test_byos.py`, written deliberately "the way a user would implement one" — so the store users are actually pointed at was never exercised, including the `SerializationError` its `read_blob` raises on a missing key.

Now covered: construction with and without a backing dict, the round-trip, the missing-key error, and a real end-to-end save/load routing a node's values through it.

## The rest

- **`_require_parent`** — saving under a directory that does not exist names *that directory*. The 0.7.0 changelog promises this, and specifically promises the error does not name the sibling `.tmp` the containers build into. Both halves are now asserted, for the zip and dir containers.
- **Named timezones** — `==` on two aware datetimes compares instants, so a round-trip that quietly replaced `Europe/London` with a fixed `+00:00` would still have passed the `AWKWARD_VALUES` table. The new table entry covers the encode and decode paths; three explicit tests assert the zone *key* survives, which is the part equality cannot see.
- **`put_blob` with raw bytes** — both the bytes and writer-callable forms are documented on `put_blob`; only the callable one was reached, because that is what the built-in transformers use.
- **`write_dill_old`** — applying the `__serialize__` tag rule, and writing to an open file object. Worth knowing: the deprecated path implements that rule a *second* time, because it has deleted `__getstate__` for the duration of the write. Only the other copy was covered, so the two could have drifted silently.

## Result

| | Before | After this PR | With #422 too |
| --- | --- | --- | --- |
| `computeengine.py` | 99% | **100%** | 100% |
| `serialization/blobs.py` | 95% | **100%** | 100% |
| `serialization/values.py` | 98% | **99%** | 99% |
| Suite total | 98.94% | **99.25%** | **99.94%** |
| Uncovered lines | 51 | 36 | **3** |

## The three lines left, and why

`ui/widget.py:947` (`_select_key` returning early with no view), `ui/widget.py:1008` (the build-request early return) and `serialization/values.py:485` (`_reapply_freq` returning unchanged when `freq is None`).

All three are reachable, so 100% is available. They are left because a test for each asserts little beyond "the guard is a guard", and because taking the gate to `--cov-fail-under=100` has a cost worth deciding separately: this codebase carries 35 considered `# pragma: no cover` markers, and a 100% bar turns every future defensive branch into a choice between a tautological test and a pragma. 99.94% with three honest gaps reads truer than 100% leaning harder on suppressions. Happy to close them if you'd rather have the round number.

## Verification

| Gate | Result |
| --- | --- |
| `make fmt` | PASS — 21/21 hooks |
| `make test` | PASS — 1557 passed, coverage 99.25% |
