### PR TITLE
docs: document the five undocumented nested helpers

### DIFF
--- a/src/loman/computeengine.py
+++ b/src/loman/computeengine.py
@@ -181,8 +181,11 @@ def _notifies_subscribers(*, graph_changed: bool = False) -> Callable[[F], F]:
     """
 
     def decorate(method: F) -> F:
+        """Wrap *method* so its changes are batched into one notification."""
+
         @functools.wraps(method)
         def wrapped(self: "Computation", *args: Any, **kwargs: Any) -> Any:
+            """Run the method inside a change batch, publishing when it unwinds."""
             if self._change_depth == 0 and not self._subscriptions:
                 return method(self, *args, **kwargs)
             self._change_depth += 1

--- a/src/loman/serialization/compression.py
+++ b/src/loman/serialization/compression.py
@@ -44,9 +44,11 @@ def _zstd_codec(level: int) -> Codec:
     import zstandard
 
     def compress(data: bytes) -> bytes:
+        """Compress *data* at the level this codec was built for."""
         return zstandard.ZstdCompressor(level=level).compress(data)
 
     def decompress(data: bytes) -> bytes:
+        """Restore the original bytes; the level is recorded in the frame."""
         return zstandard.ZstdDecompressor().decompress(data)
 
     return compress, decompress

--- a/src/loman/serialization/transformer.py
+++ b/src/loman/serialization/transformer.py
@@ -1050,6 +1050,7 @@ def _encode_frame_as_parquet(transformer: "Transformer", frame: "pd.DataFrame") 
         return None
 
     def write(f: Any) -> None:
+        """Stream the parquet table into the blob's file object."""
         pq.write_table(table, f, compression="zstd")
 
     return {


### PR DESCRIPTION
Addresses #399. **The docstrings, yes; the config change, no — and the issue's reason for it no longer holds.**

## The five helpers

Each now carries a one-line docstring in the style the package already uses for a nested helper (`_acknowledges.wrapped`, `create_root_graph._normalize_attr_value`, and a dozen others):

| File | Object |
| --- | --- |
| `computeengine.py` | `_notifies_subscribers.decorate` |
| `computeengine.py` | `_notifies_subscribers.decorate.wrapped` |
| `serialization/compression.py` | `_zstd_codec.compress` |
| `serialization/compression.py` | `_zstd_codec.decompress` |
| `serialization/transformer.py` | `_encode_frame_as_parquet.write` |

Counting nested functions, `src/` goes from **652/657 (99.2%)** to **657/657 (100.0%)**. Those were the only five missing in `src/` — no others turned up.

## Why `[tool.interrogate]` is left alone

The issue argues the two `ignore-nested-*` settings can simply be deleted, on the grounds that "interrogate is only ever pointed at `src/` — by the make target (`interrogate -vv src`) and by the pre-commit hook (`files: ^src/`) alike — so the exclusion never reached a test."

**That is no longer true of the make target.** It now runs:

```
interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic src tests
```

I measured it rather than reasoning about it. With `ignore-nested-functions = false` and `ignore-nested-classes = false`:

| Scope | Objects | Missing |
| --- | --- | --- |
| `src` | 657 | 5 — the five above |
| `src tests` | 2637 | **241** |

So deleting those two lines today does not cost five docstrings, it costs **236 more on inline test helpers** — `def b(a): return a + 1` and friends, which is precisely what the config comment defends and, I think, correctly.

The clean fix would be to let the pre-commit hook count nested functions while the make target does not, since the hook is already scoped `files: ^src/`. That needs the hook to read a different config file, and `.pre-commit-config.yaml` is **template-owned** (it is in `.rhiza/template.lock`), so it is an upstream change in `jebel-quant/rhiza` rather than one to make here.

`fail-under = 100` is separately moot: the make target already passes `--fail-under 100` on the command line.

**Net effect:** the five helpers are documented and `src/` is genuinely at 100%, but nothing yet stops a sixth appearing. That gap is real and worth tracking — I'd suggest leaving #399 open, retitled to the config question alone, rather than closing it with this PR.

## Verification

| Gate | Result |
| --- | --- |
| `make fmt` | PASS — 21/21 hooks, interrogate included |
| `make test` | PASS — 1542 passed |
| `interrogate src`, nested counted | **657/657, 100.0%** (was 652/657) |

No changelog entry — nothing here is visible to a caller.
