### PR TITLE
docs: modernise the installation guide

### DIFF
--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -1,32 +1,71 @@
 # Installation Guide
 
-## Using Pip
+## Requirements
 
-To install Loman, run the following command:
+Loman needs **Python 3.11 or newer**. Every release is tested against 3.11, 3.12, 3.13
+and 3.14 on Linux, macOS and Windows.
+
+## Installing Loman
+
+### With uv
+
+[uv](https://docs.astral.sh/uv/) is the fastest way to install Loman, and the tool this
+project itself is built with. To add Loman to a project:
+
+```bash
+$ uv add loman
+```
+
+To install it into the environment you already have:
+
+```bash
+$ uv pip install loman
+```
+
+To try it without installing anything permanently — uv builds a throwaway environment and
+discards it afterwards:
+
+```bash
+$ uv run --with loman python
+```
+
+### With pip
 
 ```bash
 $ pip install loman
 ```
 
-If you don't have [pip](https://pip.pypa.io) installed (tisk tisk!),
-[this Python installation guide](http://docs.python-guide.org/en/latest/starting/installation/)
-can guide you through the process.
+If you don't have [pip](https://pip.pypa.io) installed,
+[this Python installation guide](https://packaging.python.org/en/latest/tutorials/installing-packages/)
+will get you started.
+
+### With conda
+
+Loman is published on PyPI rather than conda-forge, so install it with pip inside your
+conda environment:
+
+```bash
+$ conda create -n loman python=3.12
+$ conda activate loman
+$ pip install loman
+```
+
+Graphviz, however, *is* on conda-forge, which makes conda a convenient way to get it —
+see below.
 
 ## Optional extras
 
-Two features are packaged as extras, so a plain `pip install loman` stays small. Neither
-is needed for the core computation engine, and nothing in a bare `import loman` imports
-either one — both are loaded lazily, at the point you use the feature.
+Two features are packaged as extras, so a plain install stays small. Neither is needed for
+the core computation engine, and nothing in a bare `import loman` imports either one —
+both are loaded lazily, at the point you use the feature.
 
-| Extra | Install | What it adds |
-|---|---|---|
-| `ui` | `pip install 'loman[ui]'` | `comp.widget()`, the live notebook graph — see [The Interactive Widget](features/querying/interactive_widget.md) |
-| `efficient` | `pip install 'loman[efficient]'` | Parquet storage for DataFrames when saving a computation |
-
-Both together:
+| Extra | What it adds |
+|---|---|
+| `ui` | `comp.widget()`, the live notebook graph — see [The Interactive Widget](features/querying/interactive_widget.md) |
+| `efficient` | Parquet storage for DataFrames when saving a computation |
 
 ```bash
-$ pip install 'loman[ui,efficient]'
+$ uv add 'loman[ui,efficient]'      # or: pip install 'loman[ui,efficient]'
 ```
 
 `efficient` is a storage-format choice rather than a capability: without it, saved frames
@@ -34,37 +73,62 @@ are written as `.npy`, which is numpy's own format and needs no extra package. I
 when you want the saved data readable by other tools; a frame pyarrow cannot represent
 falls back to the default encoding rather than failing the save.
 
-## Dependency on graphviz
+## Installing Graphviz
 
-Loman uses the [graphviz](http://www.graphviz.org/) tool, and the Python [graphviz library](https://pypi.python.org/pypi/graphviz) to draw dependency graphs. If you are using Continuum's excellent [Anaconda Python](https://www.continuum.io/downloads) distribution (recommended), then you can install them by running these commands:
+Loman draws dependency graphs by shelling out to [Graphviz](https://graphviz.org/)'s
+`dot` command. The Python glue (`pydotplus`) is installed automatically with Loman, but
+the Graphviz binaries themselves are a separate, non-Python program that you need to
+install yourself — `pip install loman` cannot do it for you.
+
+Everything else in Loman works without Graphviz; you only need it for the visualization
+features, for example `Computation.draw()` and the graph widget.
+
+### Install the binaries
+
+Graphviz publishes packages for every major platform. Its
+[official download page](https://graphviz.org/download/) has full instructions, but for
+most people one of these one-liners is enough:
+
+| Platform | Command |
+|---|---|
+| macOS (Homebrew) | `brew install graphviz` |
+| Debian / Ubuntu | `sudo apt-get install graphviz` |
+| Fedora / RHEL | `sudo dnf install graphviz` |
+| conda (any platform) | `conda install -c conda-forge graphviz` |
+| Windows (winget) | `winget install Graphviz.Graphviz` |
+| Windows (Chocolatey) | `choco install graphviz` |
+
+After installing, confirm the `dot` binary is on your `PATH`:
 
 ```bash
-$ conda install graphviz
-$ python install graphviz
+$ dot -V
+dot - graphviz version 12.0.0 (...)
 ```
 
-### Windows users: Adding the graphviz binary to your PATH
+If that prints a version, Loman's visualization features are ready to use. If it reports
+that `dot` cannot be found, see the next section.
 
-Under Windows, Anaconda's graphviz package installs the graphviz tool's binaries in a subdirectory under the bin directory, but only the bin directory is on the PATH. So we will need to add the subdirectory to the path. To find out where the bin directory is in your installation, use the where command:
+### Windows: adding the Graphviz binary to your PATH
+
+On Windows, some Graphviz installers place `dot.exe` in a directory that is not on your
+`PATH`, so Loman cannot find it even though Graphviz is installed. To fix this, locate
+`dot.exe` and add its directory to your `PATH`.
+
+To find where `dot.exe` was installed, use the `where` command (it may not find it if the
+directory isn't yet on your `PATH`, in which case look under your Graphviz installation
+directory, typically `C:\Program Files\Graphviz\bin`):
 
 ```
 C:\>where dot
-C:\ProgramData\Anaconda3\Library\bin\dot.bat
-C:\>dir C:\ProgramData\Anaconda3\Library\bin\graphviz\dot.exe
- Volume in drive C has no label.
- Volume Serial Number is XXXX-XXXX
-
- Directory of C:\ProgramData\Anaconda3\Library\bin\graphviz
-
-01/03/2017  04:16 PM             7,680 dot.exe
-           1 File(s)          7,680 bytes
-           0 Dir(s)  xx bytes free
+C:\Program Files\Graphviz\bin\dot.exe
 ```
 
-You can then add the subdirectory graphviz to your PATH. You can either do this through the Windows Control Panel, or in an interactive session, by running this code:
+You can then add that `bin` directory to your `PATH`. The permanent fix is to add it
+through the Windows *Environment Variables* control panel. To set it just for the current
+Python session, you can run:
 
 ```python
-import sys, os
+import os
 
 
 def ensure_path(path):
@@ -74,5 +138,41 @@ def ensure_path(path):
         os.environ["PATH"] = ";".join(paths)
 
 
-ensure_path(r"C:\ProgramData\Anaconda3\Library\bin\graphviz")
+ensure_path(r"C:\Program Files\Graphviz\bin")
 ```
+
+## Installing for development
+
+Loman's development environment is managed by
+[Rhiza](https://github.com/Jebel-Quant/rhiza), a template that supplies the `Makefile`,
+the CI workflows, the pre-commit hooks and the gates behind them. You do not need to
+install it: it is synced into the repository, and the `Makefile` is a thin shim that
+forwards to the `rhiza-task` CLI, fetched on demand through `uvx`.
+
+So the whole setup is:
+
+```bash
+$ git clone https://github.com/janushendersonassetallocation/loman.git
+$ cd loman
+$ make install
+```
+
+`make install` creates the virtual environment, syncs every dependency group and extra
+from `uv.lock`, installs the pre-commit hooks, and runs the repository's own
+`local-setup.sh` — which installs Graphviz if it is missing, so the visualization tests
+can run. uv is installed automatically if you do not already have it.
+
+Then:
+
+```bash
+$ make test     # the full suite, with coverage
+$ make fmt      # the pre-commit hooks over every file
+$ make all      # every gate CI runs
+$ make help     # every available target
+```
+
+`make help` is worth running once: it lists the tasks Rhiza provides and, separately, the
+targets this repository adds in `local.mk`.
+
+For what Rhiza is and where its own documentation lives, see
+[Rhiza tooling](../development/rhiza.md).


### PR DESCRIPTION
The installation page still recommended Anaconda as the way to install Loman, and told
readers to run `python install graphviz` — not a command — to get a Python library Loman
**does not use**. It made no mention of uv, of the Python versions Loman actually
supports, or of how to set the project up to work on.

## What it says now

**Requirements** — Python 3.11+, tested on 3.11 through 3.14. The page never said.

**Installing Loman** — uv first (`uv add`, `uv pip install`, and `uv run --with loman` for
a throwaway environment), pip alongside it, and conda covered honestly: Loman is published
on PyPI and *not* on conda-forge, so inside a conda environment the answer is still pip.
Graphviz **is** on conda-forge, which is why conda still earns a mention.

**Optional extras** — kept from #411, with the install line shown in both uv and pip form.

**Graphviz** — Loman shells out to `dot`; the Python glue is `pydotplus`, and it arrives
with Loman automatically. The old text named the `graphviz` PyPI package, which is not a
dependency at all. Replaced with a per-platform table, a `dot -V` check, and Windows
`PATH` guidance pointing at where current installers actually put the binary.

**Installing for development** — a new section. Clone, `make install`, done. It explains
that the environment comes from [Rhiza](https://github.com/Jebel-Quant/rhiza): the
`Makefile` is a thin shim forwarding to the `rhiza-task` CLI fetched through `uvx`, and
`make install` also runs `local-setup.sh`, which installs Graphviz so the visualization
tests can run. Then `make test` / `fmt` / `all` / `help`.

## Credit

The Graphviz sections are **@nikjascrazzy's work from #378**, resolved against the
`## Optional extras` section that landed in #411 after that PR was opened (which is why
#378 now shows a conflict), with a conda-forge row added. They are credited as
co-author on the commit. **#378 is superseded by this rather than rejected** — happy to
reverse that if they would rather land theirs first.

## Verified rather than assumed

- `tests/test_docs.py` — 7 passed.
- The **built** page contains each command as rendered text — `uv add loman`,
  `uv pip install loman`, `uv run --with loman`, `pip install loman`,
  `conda install -c conda-forge graphviz`, `make install`, `make help`.
- Both relative links resolve (`interactive_widget`, `development/rhiza`).
- `loman` is absent from conda-forge (HTTP 404) and present on PyPI (200); `graphviz` is
  on conda-forge (200) — so the conda advice is checked, not guessed.
- rhiza-task's `install` really does depend on `setup`, which is what makes the
  Graphviz claim in that section true.
- The build's single remaining warning is the pre-existing one in `release.md`
  (`../../CHANGELOG.md`, outside `docs_dir`), untouched here.

## Related

The README's Development section has its own inaccuracies — it advertises `make check`,
which is not a target, and calls the task runner "Taskfile". Out of scope here; worth a
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
